### PR TITLE
Add world tests

### DIFF
--- a/modules/World.js
+++ b/modules/World.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid"; // For generating unique IDs
+import { randomUUID } from "crypto"; // For generating unique IDs
 
 export class World {
     constructor() {
@@ -12,7 +12,7 @@ export class World {
      * @param {string} [id] - An optional unique ID. If not provided, one will be generated.
      * @returns {string} - The unique ID of the newly added room.
      */
-    addRoom(name, description, id = uuidv4()) {
+    addRoom(name, description, id = randomUUID()) {
         const room = { id, name, description, characters: [], inventory: [], exits: {} };
         this.rooms.set(id, room);
         return id;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "lint": "eslint . --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "node tests/World.test.js"
   },
   "author": "",
   "license": "MIT",

--- a/tests/World.test.js
+++ b/tests/World.test.js
@@ -1,0 +1,27 @@
+import assert from 'assert/strict';
+import { World } from '../modules/World.js';
+
+const world = new World();
+
+// addRoom should return a unique ID each time
+const id1 = world.addRoom('Room A', 'First room');
+const id2 = world.addRoom('Room B', 'Second room');
+assert.notStrictEqual(id1, id2, 'addRoom should generate unique IDs');
+
+// getRoomById should return the expected room object
+const expectedRoom = {
+    id: id1,
+    name: 'Room A',
+    description: 'First room',
+    characters: [],
+    inventory: [],
+    exits: {}
+};
+const roomById = world.getRoomById(id1);
+assert.deepStrictEqual(roomById, expectedRoom, 'getRoomById should return the correct room');
+
+// getRoomByName should return the same object
+const roomByName = world.getRoomByName('Room A');
+assert.deepStrictEqual(roomByName, expectedRoom, 'getRoomByName should return the correct room');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- use Node's `crypto.randomUUID` for generating room IDs to avoid missing dependency
- add minimal `tests/World.test.js`
- run tests with npm script
- verify returned room object in tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68637e5c63e08327ae8a06ffef4f6f5d