### PR TITLE
Use environment PORT variable

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,11 @@ import pluginJs from "@eslint/js";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {languageOptions: { globals: globals.browser }},
+  {
+    languageOptions: {
+      globals: { ...globals.node, ...globals.es2021 },
+    },
+  },
   pluginJs.configs.recommended,
   {
     files: ['*.js', '**/*.js'],

--- a/server.js
+++ b/server.js
@@ -2,7 +2,8 @@ import net from "net";
 import { handleCommand } from "./game.js";
 import { writeToSocket } from "./modules/utils.js";
 
-const PORT = 8484; // eventually process.env.PORT || 8484
+// Allow PORT to be overridden via environment variable for deployment flexibility
+const PORT = process.env.PORT || 8484;
 
 const server = net.createServer((socket) => {
     socket.character = { isLoggedIn: false }; // Initialize character state


### PR DESCRIPTION
## Summary
- use `process.env.PORT` for server port with fallback to 8484

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686388a3b2d0832790e8771c76e4ac65