### PR TITLE
Fix: initialize character.stage so the login flow actually starts

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ import { writeToSocket } from "./modules/utils.js";
 const PORT = process.env.PORT || 8484;
 
 const server = net.createServer((socket) => {
-    socket.character = { isLoggedIn: false }; // Initialize character state
+    socket.character = { isLoggedIn: false, stage: "name" }; // Initialize character state
     writeToSocket(socket, "Welcome to the game! Please enter your character's name:");
 
     socket.on("data", (data) => {


### PR DESCRIPTION
## Summary
Fixes a login bug found while working on the command registry.

`socket.character` was initialized as `{ isLoggedIn: false }` with no `stage`, but every branch in `handleLogin` (`game.js`) gates on `character.stage` being `name`, `password`, or `description`. With no stage set, all branches were skipped and `handleLogin` returned `undefined` -- a brand new connection's first message (the character name) was silently dropped instead of prompting for a password. No player could actually get through login.

## Fix
Initialize `stage: name` alongside `isLoggedIn: false` in `server.js`, where character state is first created.

## Testing
- `npm run lint` -- clean
- `npm test` -- passes (existing `World.test.js`)
- Manual smoke test mirroring `server.js`'s actual initialization: name -> password -> description -> `look`. Previously all four steps returned `undefined`; now each returns the expected prompt/response.

Generated with Claude Code