### PR TITLE
Add command registry; verbs register instead of static exports

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,5 +1,6 @@
 import { World } from "./modules/World.js";
-import * as commands from "./modules/commands/index.js";
+import { getCommand } from "./modules/commands/registry.js";
+import "./modules/commands/index.js"; // registers the built-in verbs, see index.js
 import crypto from "crypto";
 import { loadCharacters, saveCharacters } from "./data.js";
 
@@ -99,8 +100,9 @@ export const handleCommand = (socket, input) => {
     }
 
     const [command, ...args] = input.trim().split(/\s+/);
-    if (commands[command]) {
-        return commands[command](world, args, character, socket);
+    const handler = getCommand(command);
+    if (handler) {
+        return handler(world, args, character, socket);
     }
 
     return "I don't understand that command.";

--- a/modules/commands/index.js
+++ b/modules/commands/index.js
@@ -1,11 +1,28 @@
-export { drop } from './drop.js';
-export { east } from './east.js';
-export { get } from './get.js';
-export { give } from './give.js';
-export { look } from './look.js';
-export { north } from './north.js';
-export { quit } from './quit.js';
-export { south } from './south.js';
-export { tell } from './tell.js';
-export { west } from './west.js';
-export { whisper } from './whisper.js';
+// Core's built-in verbs. This is effectively the "core pack" for now —
+// content packs will register their own verbs the same way, by importing
+// registerCommand from registry.js and calling it, without touching this
+// file (see ARCHITECTURE.md).
+import { registerCommand } from "./registry.js";
+import { drop } from "./drop.js";
+import { east } from "./east.js";
+import { get } from "./get.js";
+import { give } from "./give.js";
+import { look } from "./look.js";
+import { north } from "./north.js";
+import { quit } from "./quit.js";
+import { south } from "./south.js";
+import { tell } from "./tell.js";
+import { west } from "./west.js";
+import { whisper } from "./whisper.js";
+
+registerCommand("drop", drop);
+registerCommand("east", east);
+registerCommand("get", get);
+registerCommand("give", give);
+registerCommand("look", look);
+registerCommand("north", north);
+registerCommand("quit", quit);
+registerCommand("south", south);
+registerCommand("tell", tell);
+registerCommand("west", west);
+registerCommand("whisper", whisper);

--- a/modules/commands/registry.js
+++ b/modules/commands/registry.js
@@ -1,0 +1,29 @@
+// Engine-side command registry (see ARCHITECTURE.md).
+//
+// Core ships a handful of built-in verbs (see index.js), but the registry
+// itself is theme-agnostic: a content pack registers its own verbs by
+// calling registerCommand the same way core does, without editing this file
+// or index.js.
+
+const commands = new Map();
+
+/**
+ * Register a command handler under a verb name.
+ * @param {string} name - The verb a player types to invoke this command.
+ * @param {(world: object, args: string[], character: object, socket: object) => (string|void)} handler
+ */
+export function registerCommand(name, handler) {
+    if (commands.has(name)) {
+        throw new Error(`Command "${name}" is already registered.`);
+    }
+    commands.set(name, handler);
+}
+
+/**
+ * Look up the handler registered for a verb.
+ * @param {string} name - The verb to look up.
+ * @returns {Function|undefined} The handler, or undefined if nothing is registered.
+ */
+export function getCommand(name) {
+    return commands.get(name);
+}


### PR DESCRIPTION
﻿## Summary
Adds a theme-agnostic command registry per the Phase 1 build order in ARCHITECTURE.md, as the first step toward separating engine from content packs.

- New modules/commands/registry.js: registerCommand(name, handler) / getCommand(name). Throws on duplicate registration.
- modules/commands/index.js now registers each built-in verb instead of statically re-exporting it. This is effectively the "core pack" for now. A future content pack registers its own verbs the same way (import registerCommand, call it) without editing this file.
- game.js dispatches through getCommand instead of a plain object property lookup. Behavior is unchanged.

## Testing
- npm run lint: clean
- npm test: passes (existing World.test.js)
- Manual smoke test through login, look, north (no exit), and an unknown verb, confirming dispatch still resolves correctly through the registry.

Generated with Claude Code
