### PR TITLE
Add event bus; wire command/enterRoom/leaveRoom events

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,12 +59,17 @@ as locked in before it's been used.
 
 ## Build order (Phase 1)
 
-1. **Command registry** — `registerCommand(name, handler)` replacing the
-   static exports in `modules/commands/index.js`. Self-contained, low risk,
-   proves the "theme adds verbs without touching core" story on its own,
-   and previews the event-bus dispatch pattern in miniature.
-2. **Event bus** — `onEnterRoom`, `onCommand`, `onDamage`, `onTick`,
-   `onDeath`, etc.
+1. **Command registry** (done) — `registerCommand(name, handler)` replacing
+   the static exports in `modules/commands/index.js`. Self-contained, low
+   risk, proves the "theme adds verbs without touching core" story on its
+   own, and previews the event-bus dispatch pattern in miniature.
+2. **Event bus** (done) — `modules/events.js` (`on`/`emit`), multiple
+   listeners per event. Wired so far: `command` (after dispatch, in
+   `game.js`) and `enterRoom`/`leaveRoom` (room movement, in
+   `modules/commands/move.js`, shared by the directional commands). `onDamage`
+   and `onTick` stay unwired until combat (Phase 2) and the game clock
+   (Phase 3) exist to emit them — no point guessing at their payload shape
+   before the systems that produce them are real.
 3. **Entity component bags** — apply the model above to `Character`, `Item`,
    `Room`. Most invasive step; done after the registry pattern above is
    proven rather than inventing both patterns at once.

--- a/game.js
+++ b/game.js
@@ -1,6 +1,7 @@
 import { World } from "./modules/World.js";
 import { getCommand } from "./modules/commands/registry.js";
 import "./modules/commands/index.js"; // registers the built-in verbs, see index.js
+import { emit } from "./modules/events.js";
 import crypto from "crypto";
 import { loadCharacters, saveCharacters } from "./data.js";
 
@@ -102,7 +103,9 @@ export const handleCommand = (socket, input) => {
     const [command, ...args] = input.trim().split(/\s+/);
     const handler = getCommand(command);
     if (handler) {
-        return handler(world, args, character, socket);
+        const result = handler(world, args, character, socket);
+        emit("command", { character, command, args, result, world });
+        return result;
     }
 
     return "I don't understand that command.";

--- a/modules/commands/east.js
+++ b/modules/commands/east.js
@@ -1,39 +1,6 @@
-import { writeToSocket } from "../utils.js";
+import { movePlayer } from "./move.js";
 
 export const east = (world, args, character) => {
     const room = world.getRoomById(character.roomId);
-
-    if (!room.exits || !room.exits.east) {
-        return "You can't go that way.";
-    }
-
-    const nextRoom = world.getRoomById(room.exits.east);
-    if (!nextRoom) {
-        return "That path leads nowhere.";
-    }
-
-    // Broadcast the departure
-    room.characters.forEach(char => {
-        if (char !== character && char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} leaves to the east.`
-            );
-        }
-    });
-
-    // Update the character's room ID
-    character.roomId = nextRoom.id;
-
-    // Broadcast the arrival
-    nextRoom.characters.forEach(char => {
-        if (char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} arrives from the south.`
-            );
-        }
-    });
-
-    return `You move east to ${nextRoom.name}.\n${nextRoom.description}`;
+    return movePlayer(world, character, room, "east", "west");
 };

--- a/modules/commands/move.js
+++ b/modules/commands/move.js
@@ -1,0 +1,45 @@
+import { writeToSocket } from "../utils.js";
+import { emit } from "../events.js";
+
+// Shared room-transition logic used by the directional commands
+// (north/south/east/west). Pulled out so there's one place that emits
+// leaveRoom/enterRoom, instead of four call sites to keep in sync.
+export const movePlayer = (world, character, room, direction, opposite) => {
+    if (!room.exits || !room.exits[direction]) {
+        return "You can't go that way.";
+    }
+
+    const nextRoom = world.getRoomById(room.exits[direction]);
+    if (!nextRoom) {
+        return "That path leads nowhere.";
+    }
+
+    emit("leaveRoom", { character, room, world });
+
+    // Broadcast the departure
+    room.characters.forEach(char => {
+        if (char !== character && char.socket) {
+            writeToSocket(
+                char.socket,
+                `${character.name} leaves to the ${direction}.`
+            );
+        }
+    });
+
+    // Update the character's room ID
+    character.roomId = nextRoom.id;
+
+    // Broadcast the arrival
+    nextRoom.characters.forEach(char => {
+        if (char.socket) {
+            writeToSocket(
+                char.socket,
+                `${character.name} arrives from the ${opposite}.`
+            );
+        }
+    });
+
+    emit("enterRoom", { character, room: nextRoom, world });
+
+    return `You move ${direction} to ${nextRoom.name}.\n${nextRoom.description}`;
+};

--- a/modules/commands/north.js
+++ b/modules/commands/north.js
@@ -1,39 +1,6 @@
-import { writeToSocket } from "../utils.js";
+import { movePlayer } from "./move.js";
 
 export const north = (world, args, character) => {
     const room = world.getRoomById(character.roomId);
-
-    if (!room.exits || !room.exits.north) {
-        return "You can't go that way.";
-    }
-
-    const nextRoom = world.getRoomById(room.exits.north);
-    if (!nextRoom) {
-        return "That path leads nowhere.";
-    }
-
-    // Broadcast the departure
-    room.characters.forEach(char => {
-        if (char !== character && char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} leaves to the north.`
-            );
-        }
-    });
-
-    // Update the character's room ID
-    character.roomId = nextRoom.id;
-
-    // Broadcast the arrival
-    nextRoom.characters.forEach(char => {
-        if (char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} arrives from the south.`
-            );
-        }
-    });
-
-    return `You move north to ${nextRoom.name}.\n${nextRoom.description}`;
+    return movePlayer(world, character, room, "north", "south");
 };

--- a/modules/commands/south.js
+++ b/modules/commands/south.js
@@ -1,39 +1,6 @@
-import { writeToSocket } from "../utils.js";
+import { movePlayer } from "./move.js";
 
 export const south = (world, args, character) => {
     const room = world.getRoomById(character.roomId);
-
-    if (!room.exits || !room.exits.south) {
-        return "You can't go that way.";
-    }
-
-    const nextRoom = world.getRoomById(room.exits.south);
-    if (!nextRoom) {
-        return "That path leads nowhere.";
-    }
-
-    // Broadcast the departure
-    room.characters.forEach(char => {
-        if (char !== character && char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} leaves to the south.`
-            );
-        }
-    });
-
-    // Update the character's room ID
-    character.roomId = nextRoom.id;
-
-    // Broadcast the arrival
-    nextRoom.characters.forEach(char => {
-        if (char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} arrives from the south.`
-            );
-        }
-    });
-
-    return `You move south to ${nextRoom.name}.\n${nextRoom.description}`;
+    return movePlayer(world, character, room, "south", "north");
 };

--- a/modules/commands/west.js
+++ b/modules/commands/west.js
@@ -1,39 +1,6 @@
-import { writeToSocket } from "../utils.js";
+import { movePlayer } from "./move.js";
 
 export const west = (world, args, character) => {
     const room = world.getRoomById(character.roomId);
-
-    if (!room.exits || !room.exits.west) {
-        return "You can't go that way.";
-    }
-
-    const nextRoom = world.getRoomById(room.exits.west);
-    if (!nextRoom) {
-        return "That path leads nowhere.";
-    }
-
-    // Broadcast the departure
-    room.characters.forEach(char => {
-        if (char !== character && char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} leaves to the west.`
-            );
-        }
-    });
-
-    // Update the character's room ID
-    character.roomId = nextRoom.id;
-
-    // Broadcast the arrival
-    nextRoom.characters.forEach(char => {
-        if (char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} arrives from the south.`
-            );
-        }
-    });
-
-    return `You move west to ${nextRoom.name}.\n${nextRoom.description}`;
+    return movePlayer(world, character, room, "west", "east");
 };

--- a/modules/events.js
+++ b/modules/events.js
@@ -1,0 +1,47 @@
+// Engine-side event bus (see ARCHITECTURE.md / ROADMAP.md).
+//
+// Theme packs hook behavior by listening for events instead of editing core
+// logic directly, e.g. `on("enterRoom", handler)` instead of patching
+// game.js. Core emits the events; the listeners themselves are entirely
+// theme-owned.
+//
+// Unlike the command registry (one verb = one handler), multiple listeners
+// can be registered for the same event — more than one pack may care about
+// the same lifecycle moment.
+
+const listeners = new Map();
+
+/**
+ * Register a listener for an event.
+ * @param {string} eventName - The event to listen for.
+ * @param {(payload: object) => void} handler
+ */
+export function on(eventName, handler) {
+    if (!listeners.has(eventName)) {
+        listeners.set(eventName, []);
+    }
+    listeners.get(eventName).push(handler);
+}
+
+/**
+ * Fire an event, calling every listener registered for it in registration
+ * order. A listener that throws is logged and skipped rather than allowed
+ * to stop sibling listeners or crash the caller — content packs are
+ * semi-trusted, and one broken listener shouldn't take down the others.
+ * @param {string} eventName - The event to fire.
+ * @param {object} [payload] - Event-specific data, passed as-is to each listener.
+ */
+export function emit(eventName, payload) {
+    const handlers = listeners.get(eventName);
+    if (!handlers) {
+        return;
+    }
+
+    for (const handler of handlers) {
+        try {
+            handler(payload);
+        } catch (err) {
+            console.error(`Error in "${eventName}" event listener:`, err);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "node tests/World.test.js"
+    "test": "node tests/World.test.js && node tests/events.test.js"
   },
   "author": "",
   "license": "MIT",

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,0 +1,37 @@
+import assert from 'assert/strict';
+import { on, emit } from '../modules/events.js';
+
+// emit with no listeners registered should be a silent no-op
+assert.doesNotThrow(() => emit('nothingListening', { foo: 'bar' }));
+
+// multiple listeners on the same event should all fire, in registration order
+const calls = [];
+on('testEvent', (payload) => calls.push(['first', payload]));
+on('testEvent', (payload) => calls.push(['second', payload]));
+emit('testEvent', { value: 42 });
+assert.deepStrictEqual(calls, [
+    ['first', { value: 42 }],
+    ['second', { value: 42 }],
+], 'both listeners should fire, in registration order, with the same payload');
+
+// a listener that throws should be logged and skipped, not stop sibling listeners
+const order = [];
+on('faultyEvent', () => {
+    order.push('before-throw');
+    throw new Error('listener boom');
+});
+on('faultyEvent', () => order.push('after-throw'));
+
+const originalConsoleError = console.error;
+let loggedError = false;
+console.error = () => { loggedError = true; };
+try {
+    assert.doesNotThrow(() => emit('faultyEvent', {}));
+} finally {
+    console.error = originalConsoleError;
+}
+
+assert.deepStrictEqual(order, ['before-throw', 'after-throw'], 'a throwing listener should not block the next listener');
+assert.ok(loggedError, 'a throwing listener should be logged');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
Phase 1 step 2 of the engine-hardening roadmap (see ARCHITECTURE.md's build order): a theme-agnostic event bus so content packs can hook behavior instead of editing core logic directly.

- `modules/events.js` — `on(eventName, handler)` / `emit(eventName, payload)`. Multiple listeners per event are allowed (unlike the command registry, where one verb = one handler). `emit` calls listeners synchronously in registration order; a listener that throws is logged and skipped rather than blocking siblings or crashing the caller — content packs are semi-trusted.
- Wired the two events that have a real trigger in the current codebase:
  - `command` — fires in `game.js` after a verb handler runs, with `{ character, command, args, result, world }`.
  - `enterRoom` / `leaveRoom` — fire on room movement.
- Pulled the duplicated room-transition logic out of `north/south/east/west.js` into a shared `modules/commands/move.js` helper, so there's one `emit` site instead of four to keep in sync. As a side effect this fixes a pre-existing copy/paste bug where south/east/west always announced arrivals as "from the south."
- `onDamage`/`onTick`/`onDeath` stay documented-but-unwired until combat (Phase 2) and the game clock (Phase 3) actually exist to produce them.

## Testing
- `npm test` — added `tests/events.test.js` (multi-listener fan-out/order, fault isolation, no-op on unlistened event) alongside the existing World test.
- `npm run lint` — clean.
- Manual smoke test of `movePlayer` + event emission confirmed room transition and event order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)