### PR TITLE
Add entity component bags; wire Character/Item/Room into the live server

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,9 +70,17 @@ as locked in before it's been used.
    and `onTick` stay unwired until combat (Phase 2) and the game clock
    (Phase 3) exist to emit them — no point guessing at their payload shape
    before the systems that produce them are real.
-3. **Entity component bags** — apply the model above to `Character`, `Item`,
-   `Room`. Most invasive step; done after the registry pattern above is
-   proven rather than inventing both patterns at once.
+3. **Entity component bags** (done) — `Character`/`Item`/`Room` each carry
+   `this.components = {}`. Turned out to be more invasive than "add a
+   field": none of the three classes were actually instantiated anywhere in
+   the running server (`World.addRoom` and the login flow built plain
+   object literals instead), so the bag would've sat on dead code. Fixing
+   that surfaced real bugs from the same root cause — `character.socket`
+   was never assigned (so broadcasts to other players silently no-opped),
+   `character.keywords` was never populated (keyword target-matching was
+   dead), and room membership drifted on movement (`roomId` updated,
+   `room.characters` didn't). All fixed alongside the bags, since wiring up
+   real entities was the actual prerequisite for the bags to mean anything.
 4. **Data-driven definitions** — move room/item/NPC data out of JS into
    pack-owned data files, using the pack layout above.
 

--- a/game.js
+++ b/game.js
@@ -22,11 +22,11 @@ function handleLogin(socket, input) {
         }
 
         if (characters[input]) {
-            character.name = input;
+            character.setName(input);
             character.stage = "password";
             return "Enter your password:";
         } else {
-            character.name = input;
+            character.setName(input);
             character.stage = "password";
             character.new = true;
             return "Creating a new character. Enter a password:";
@@ -59,8 +59,7 @@ function handleLogin(socket, input) {
                 startingRoom = world.getRoomById(roomId);
             }
 
-            startingRoom.characters.push(character);
-            character.roomId = startingRoom.id; // Store the room ID in the character
+            startingRoom.addCharacter(character);
 
             return `Welcome back, ${character.name}!`;
         } else {
@@ -86,8 +85,7 @@ function handleLogin(socket, input) {
             startingRoom = world.getRoomById(roomId);
         }
 
-        startingRoom.characters.push(character);
-        character.roomId = startingRoom.id; // Store the room ID in the character
+        startingRoom.addCharacter(character);
 
         return `Welcome, ${character.name}! Your description: "${input}"`;
     }

--- a/modules/Character.js
+++ b/modules/Character.js
@@ -1,9 +1,32 @@
 export class Character {
-    constructor(name, description) {
-        this.name = name;
-        this.keywords = name.toLowerCase().split(" ");
+    constructor(name = null, description = null) {
+        this.name = null;
+        this.keywords = [];
         this.description = description;
         this.inventory = [];
-        this.room = null;
+
+        // Connection/session state
+        this.isLoggedIn = false;
+        this.stage = "name";
+        this.roomId = null;
+        this.socket = null;
+
+        // Theme-owned data (see ARCHITECTURE.md). Core never reads/writes
+        // into this for a specific theme's keys.
+        this.components = {};
+
+        if (name) {
+            this.setName(name);
+        }
+    }
+
+    /**
+     * Set the character's name, keeping `keywords` (used for target
+     * matching by verbs like look/give/tell) derived from it.
+     * @param {string} name
+     */
+    setName(name) {
+        this.name = name;
+        this.keywords = name.toLowerCase().split(" ");
     }
 }

--- a/modules/Item.js
+++ b/modules/Item.js
@@ -3,5 +3,9 @@ export class Item {
         this.name = name;
         this.description = description;
         this.keywords = keywords;
+
+        // Theme-owned data (see ARCHITECTURE.md). Core never reads/writes
+        // into this for a specific theme's keys.
+        this.components = {};
     }
 }

--- a/modules/Room.js
+++ b/modules/Room.js
@@ -5,14 +5,21 @@ export class Room {
         this.characters = [];
         this.inventory = [];
         this.exits = {};
+
+        // Theme-owned data (see ARCHITECTURE.md). Core never reads/writes
+        // into this for a specific theme's keys.
+        this.components = {};
     }
 
     addCharacter(character) {
         this.characters.push(character);
-        character.room = this;
+        character.roomId = this.id;
     }
 
     removeCharacter(character) {
         this.characters = this.characters.filter(c => c !== character);
+        if (character.roomId === this.id) {
+            character.roomId = null;
+        }
     }
 }

--- a/modules/World.js
+++ b/modules/World.js
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto"; // For generating unique IDs
+import { Room } from "./Room.js";
 
 export class World {
     constructor() {
@@ -13,7 +14,8 @@ export class World {
      * @returns {string} - The unique ID of the newly added room.
      */
     addRoom(name, description, id = randomUUID()) {
-        const room = { id, name, description, characters: [], inventory: [], exits: {} };
+        const room = new Room(name, description);
+        room.id = id;
         this.rooms.set(id, room);
         return id;
     }

--- a/modules/commands/get.js
+++ b/modules/commands/get.js
@@ -1,6 +1,6 @@
-export const get = (game, args, player) => {
+export const get = (world, args, character) => {
     const keyword = args[0];
-    const { room } = player;
+    const room = world.getRoomById(character.roomId);
 
     if (!keyword) {
         return "What do you want to get?";
@@ -15,9 +15,9 @@ export const get = (game, args, player) => {
         return "You can't find that here.";
     }
 
-    // Move the item to the player's inventory
+    // Move the item to the character's inventory
     const [item] = room.inventory.splice(itemIndex, 1);
-    player.inventory.push(item);
+    character.inventory.push(item);
 
     return `You pick up ${item.name}.`;
 };

--- a/modules/commands/move.js
+++ b/modules/commands/move.js
@@ -26,12 +26,14 @@ export const movePlayer = (world, character, room, direction, opposite) => {
         }
     });
 
-    // Update the character's room ID
-    character.roomId = nextRoom.id;
+    // Move the character between rooms, keeping room.characters and
+    // character.roomId in sync
+    room.removeCharacter(character);
+    nextRoom.addCharacter(character);
 
     // Broadcast the arrival
     nextRoom.characters.forEach(char => {
-        if (char.socket) {
+        if (char !== character && char.socket) {
             writeToSocket(
                 char.socket,
                 `${character.name} arrives from the ${opposite}.`

--- a/modules/commands/quit.js
+++ b/modules/commands/quit.js
@@ -4,16 +4,17 @@ export const quit = (world, args, character, socket) => {
     const room = world.getRoomById(character.roomId);
 
     // Broadcast to the room about the disconnection
-    const remainingCharacters = room.characters.filter(char => char !== character);
-    remainingCharacters.forEach(char => 
-        writeToSocket(
-            char.socket,
-            `${character.name} has left the game.`
-        )
-    );
+    room.characters.forEach(char => {
+        if (char !== character && char.socket) {
+            writeToSocket(
+                char.socket,
+                `${character.name} has left the game.`
+            );
+        }
+    });
 
     // Remove the character from the room
-    room.characters = remainingCharacters;
+    room.removeCharacter(character);
 
     // Socket cleanup
     socket.write("Disconnecting..."); // send the closing message separately...

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "node tests/World.test.js && node tests/events.test.js"
+    "test": "node tests/World.test.js && node tests/events.test.js && node tests/components.test.js"
   },
   "author": "",
   "license": "MIT",

--- a/server.js
+++ b/server.js
@@ -1,12 +1,14 @@
 import net from "net";
 import { handleCommand } from "./game.js";
 import { writeToSocket } from "./modules/utils.js";
+import { Character } from "./modules/Character.js";
 
 // Allow PORT to be overridden via environment variable for deployment flexibility
 const PORT = process.env.PORT || 8484;
 
 const server = net.createServer((socket) => {
-    socket.character = { isLoggedIn: false, stage: "name" }; // Initialize character state
+    socket.character = new Character(); // Initialize character state
+    socket.character.socket = socket;
     writeToSocket(socket, "Welcome to the game! Please enter your character's name:");
 
     socket.on("data", (data) => {

--- a/tests/World.test.js
+++ b/tests/World.test.js
@@ -1,5 +1,6 @@
 import assert from 'assert/strict';
 import { World } from '../modules/World.js';
+import { Room } from '../modules/Room.js';
 
 const world = new World();
 
@@ -9,14 +10,8 @@ const id2 = world.addRoom('Room B', 'Second room');
 assert.notStrictEqual(id1, id2, 'addRoom should generate unique IDs');
 
 // getRoomById should return the expected room object
-const expectedRoom = {
-    id: id1,
-    name: 'Room A',
-    description: 'First room',
-    characters: [],
-    inventory: [],
-    exits: {}
-};
+const expectedRoom = new Room('Room A', 'First room');
+expectedRoom.id = id1;
 const roomById = world.getRoomById(id1);
 assert.deepStrictEqual(roomById, expectedRoom, 'getRoomById should return the correct room');
 

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -1,0 +1,45 @@
+import assert from 'assert/strict';
+import { Character } from '../modules/Character.js';
+import { Room } from '../modules/Room.js';
+import { Item } from '../modules/Item.js';
+
+// Each entity gets its own components bag, not shared across instances
+const charA = new Character('Alice');
+const charB = new Character('Bob');
+charA.components.caster = { mana: 50 };
+assert.deepStrictEqual(charA.components, { caster: { mana: 50 } });
+assert.deepStrictEqual(charB.components, {}, 'components must not leak across Character instances');
+
+const roomA = new Room('Room A', 'First room');
+const roomB = new Room('Room B', 'Second room');
+roomA.components.weather = { raining: true };
+assert.deepStrictEqual(roomB.components, {}, 'components must not leak across Room instances');
+
+const itemA = new Item('Sword', 'A sharp sword', ['sword']);
+const itemB = new Item('Shield', 'A sturdy shield', ['shield']);
+itemA.components.weapon = { damage: 5 };
+assert.deepStrictEqual(itemB.components, {}, 'components must not leak across Item instances');
+
+// setName keeps name/keywords in sync; a fresh Character has neither set
+const freshCharacter = new Character();
+assert.equal(freshCharacter.name, null);
+assert.deepStrictEqual(freshCharacter.keywords, []);
+freshCharacter.setName('Old Tom');
+assert.equal(freshCharacter.name, 'Old Tom');
+assert.deepStrictEqual(freshCharacter.keywords, ['old', 'tom']);
+
+// Room.addCharacter/removeCharacter keep room.characters and
+// character.roomId in sync in both directions
+const roomWithId = new Room('Room C', 'Third room');
+roomWithId.id = 'room-c';
+const mover = new Character('Mover');
+
+roomWithId.addCharacter(mover);
+assert.equal(mover.roomId, 'room-c');
+assert.ok(roomWithId.characters.includes(mover));
+
+roomWithId.removeCharacter(mover);
+assert.equal(mover.roomId, null);
+assert.ok(!roomWithId.characters.includes(mover));
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
Phase 1 step 3 of the engine-hardening roadmap (see ARCHITECTURE.md's build order): `Character`/`Item`/`Room` each carry `this.components = {}`, a theme-owned bag for data core never reads/writes (e.g. `{ caster: { mana: 50 } }`), per the model already documented in ARCHITECTURE.md.

**Turned out to be more than "add a field":** none of the three classes were actually instantiated anywhere in the running server — `World.addRoom` and the login flow built plain object literals instead of `new Room(...)`/`new Character(...)`, so the bag would've sat on dead code. Wiring up real instantiation was the actual prerequisite, and doing that surfaced real bugs from the same root cause:

- `character.socket` was never assigned, so every broadcast to *other* players in a room (movement, `drop`, `give`, `look`) silently no-opped — players never saw each other do anything.
- `character.keywords` was never populated, so `look`/`give`/`tell`/`whisper`'s target-matching by keyword was dead code.
- `movePlayer` updated `character.roomId` but never touched `room.characters`/`nextRoom.characters`, so room occupant lists went stale after the first move.
- `commands/get.js` destructured the never-set `player.room` instead of `character.roomId` + `world.getRoomById` like every sibling command.

## Changes
- `Character`/`Item`/`Room` constructors gain `components`. `Character` also gains the session fields it was already being mutated with (`isLoggedIn`, `stage`, `roomId`, `socket`) plus a `setName()` method that keeps `name`/`keywords` in sync.
- `Room.addCharacter`/`removeCharacter` (existed, unused) now sync `character.roomId`, and are used everywhere room membership changes: login, `move.js`, `quit.js`.
- `World.addRoom` constructs a real `Room` instead of an object literal; `server.js` constructs a real `Character` and attaches the socket.
- Fixed `get.js` to match the rest of the command modules.
- `move.js`'s arrival broadcast now excludes the mover (needed since `nextRoom.characters` actually contains them now); `quit.js`'s departure broadcast gained the `if (char.socket)` guard every other broadcast site already has.

**Explicitly out of scope** (see ARCHITECTURE.md / PR description): persisting `components` to `characters.json`, and the pre-existing bug where a player who disconnects without `quit` is never removed from their room.

## Testing
- `npm test` — added `tests/components.test.js` (components isolation across instances, `setName`, room-membership sync); updated `tests/World.test.js` since `Room` is now a real class (deepStrictEqual needs matching prototypes).
- `npm run lint` — clean.
- Manual smoke test: two real socket connections against a live server, logging in as separate characters — confirmed `look` now shows the other player and `tell` is delivered to the other socket live, both previously silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)