### PR TITLE
Add data-driven room/item content, closing out Phase 1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,8 +81,19 @@ as locked in before it's been used.
    dead), and room membership drifted on movement (`roomId` updated,
    `room.characters` didn't). All fixed alongside the bags, since wiring up
    real entities was the actual prerequisite for the bags to mean anything.
-4. **Data-driven definitions** — move room/item/NPC data out of JS into
-   pack-owned data files, using the pack layout above.
+4. **Data-driven definitions** (done) — room/item data moved out of JS into
+   `content/rooms.json`/`content/items.json`, loaded at startup by
+   `modules/content/loadWorldData.js`. Named `content/`, not `data/` per
+   the pack layout above — `data.js` (character persistence) already owns
+   that name at the repo root. This is "core's" content for now, the same
+   framing already used for `modules/commands/index.js`; it moves under a
+   real pack layout once Phase 4 builds one. NPC data isn't handled here —
+   there's no NPC entity/class yet (Phase 3), so there's nothing real to
+   load a shape for.
+
+Phase 1 is complete as of this step: current game behaves the same, but
+commands, events, entities, and content are all now pluggable rather than
+hardcoded.
 
 Game clock/scheduler is Phase 3 in the roadmap, not part of this list —
 it's needed for NPC brains, not for the engine/content split itself.

--- a/content/items.json
+++ b/content/items.json
@@ -1,0 +1,8 @@
+[
+  {
+    "key": "rusty-key",
+    "name": "a rusty key",
+    "description": "An old rusty key. It might open something nearby.",
+    "keywords": ["rusty", "key"]
+  }
+]

--- a/content/rooms.json
+++ b/content/rooms.json
@@ -1,0 +1,20 @@
+[
+  {
+    "key": "starting-room",
+    "name": "Starting Room",
+    "description": "A simple starting room.",
+    "isStartingRoom": true,
+    "exits": {
+      "north": "narrow-hallway"
+    },
+    "items": ["rusty-key"]
+  },
+  {
+    "key": "narrow-hallway",
+    "name": "Narrow Hallway",
+    "description": "A dim, narrow hallway. It leads back south.",
+    "exits": {
+      "south": "starting-room"
+    }
+  }
+]

--- a/game.js
+++ b/game.js
@@ -2,10 +2,12 @@ import { World } from "./modules/World.js";
 import { getCommand } from "./modules/commands/registry.js";
 import "./modules/commands/index.js"; // registers the built-in verbs, see index.js
 import { emit } from "./modules/events.js";
+import { loadWorldData } from "./modules/content/loadWorldData.js";
 import crypto from "crypto";
 import { loadCharacters, saveCharacters } from "./data.js";
 
 const world = new World(); // Initialize the world
+const { startingRoomKey } = loadWorldData(world); // Load room/item content data
 const characters = loadCharacters(); // Load saved characters
 
 function hashPassword(password) {
@@ -52,14 +54,7 @@ function handleLogin(socket, input) {
             character.isLoggedIn = true;
             character.stage = null;
 
-            // Retrieve or create the "Starting Room"
-            let startingRoom = world.getRoomByName("Starting Room");
-            if (!startingRoom) {
-                const roomId = world.addRoom("Starting Room", "A simple starting room.");
-                startingRoom = world.getRoomById(roomId);
-            }
-
-            startingRoom.addCharacter(character);
+            world.getRoomById(startingRoomKey).addCharacter(character);
 
             return `Welcome back, ${character.name}!`;
         } else {
@@ -78,14 +73,7 @@ function handleLogin(socket, input) {
         character.isLoggedIn = true;
         character.stage = null;
 
-        // Retrieve or create the "Starting Room"
-        let startingRoom = world.getRoomByName("Starting Room");
-        if (!startingRoom) {
-            const roomId = world.addRoom("Starting Room", "A simple starting room.");
-            startingRoom = world.getRoomById(roomId);
-        }
-
-        startingRoom.addCharacter(character);
+        world.getRoomById(startingRoomKey).addCharacter(character);
 
         return `Welcome, ${character.name}! Your description: "${input}"`;
     }

--- a/modules/content/loadWorldData.js
+++ b/modules/content/loadWorldData.js
@@ -21,6 +21,25 @@ function readJson(filePath) {
     return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
+// A duplicate key is a data integrity error, not a dangling reference —
+// `World` stores rooms in a Map keyed by `key`, so a repeat would silently
+// clobber the earlier room (and, once exits/items are wired up, merge both
+// entries' content onto whichever one survived) rather than fail visibly.
+// Same idea for items: a repeat would just make the second definition
+// permanently unreachable. Treat both as fatal, same as a JSON parse
+// failure — it's our own core data, so fail loudly at startup rather than
+// silently produce a corrupted world.
+function assertUniqueKeys(entries, label) {
+    const seen = new Set();
+    for (const entry of entries) {
+        if (!entry.key) continue;
+        if (seen.has(entry.key)) {
+            throw new Error(`Duplicate ${label} key "${entry.key}" in content data.`);
+        }
+        seen.add(entry.key);
+    }
+}
+
 /**
  * Load room/item content data into a World.
  * @param {import("../World.js").World} world
@@ -32,6 +51,9 @@ function readJson(filePath) {
 export function loadWorldData(world, contentDir = DEFAULT_CONTENT_DIR) {
     const rooms = readJson(path.join(contentDir, "rooms.json"));
     const items = readJson(path.join(contentDir, "items.json"));
+
+    assertUniqueKeys(rooms, "room");
+    assertUniqueKeys(items, "item");
 
     let startingRoomKey = null;
 

--- a/modules/content/loadWorldData.js
+++ b/modules/content/loadWorldData.js
@@ -1,0 +1,81 @@
+// Loads room/item definitions out of JSON data files into a World, instead
+// of them being hardcoded in JS (see ARCHITECTURE.md's Phase 1 build
+// order). This is effectively "core's" content for now — the same "core
+// pack" framing already used for modules/commands/index.js — living at the
+// repo's top-level content/ directory rather than nested under a real pack
+// layout, since that's Phase 4 scope.
+//
+// NPC definitions aren't handled here: there's no NPC entity/class in the
+// codebase yet, so there's nothing real to load data into (Phase 3).
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { Item } from "../Item.js";
+
+const DEFAULT_CONTENT_DIR = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..", "..", "content"
+);
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+/**
+ * Load room/item content data into a World.
+ * @param {import("../World.js").World} world
+ * @param {string} [contentDir] - Directory containing rooms.json/items.json.
+ *   Defaults to the repo's top-level content/ directory. Overridable so
+ *   tests (or, eventually, other packs) can point at their own data.
+ * @returns {{ startingRoomKey: string|null }}
+ */
+export function loadWorldData(world, contentDir = DEFAULT_CONTENT_DIR) {
+    const rooms = readJson(path.join(contentDir, "rooms.json"));
+    const items = readJson(path.join(contentDir, "items.json"));
+
+    let startingRoomKey = null;
+
+    // First pass: create every room, so exit/item references below can
+    // target any of them regardless of declaration order.
+    for (const room of rooms) {
+        if (!room.key || !room.name) {
+            console.warn("Skipping room with missing key/name:", room);
+            continue;
+        }
+        world.addRoom(room.name, room.description ?? "", room.key);
+        if (room.isStartingRoom) {
+            startingRoomKey = room.key;
+        }
+    }
+
+    if (!startingRoomKey && rooms.length > 0) {
+        console.warn('No room marked "isStartingRoom"; defaulting to the first room.');
+        startingRoomKey = rooms[0].key;
+    }
+
+    // Second pass: wire up exits and place items, now that every room key
+    // is guaranteed to resolve.
+    for (const roomData of rooms) {
+        if (!roomData.key) continue;
+        const room = world.getRoomById(roomData.key);
+
+        for (const [direction, targetKey] of Object.entries(roomData.exits ?? {})) {
+            if (!world.getRoomById(targetKey)) {
+                console.warn(`Skipping exit "${direction}" from "${roomData.key}": unknown room "${targetKey}".`);
+                continue;
+            }
+            room.exits[direction] = targetKey;
+        }
+
+        for (const itemKey of roomData.items ?? []) {
+            const itemData = items.find(item => item.key === itemKey);
+            if (!itemData) {
+                console.warn(`Skipping item "${itemKey}" in room "${roomData.key}": no such item defined.`);
+                continue;
+            }
+            room.inventory.push(new Item(itemData.name, itemData.description, itemData.keywords ?? []));
+        }
+    }
+
+    return { startingRoomKey };
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "node tests/World.test.js && node tests/events.test.js && node tests/components.test.js"
+    "test": "node tests/World.test.js && node tests/events.test.js && node tests/components.test.js && node tests/loadWorldData.test.js"
   },
   "author": "",
   "license": "MIT",

--- a/tests/loadWorldData.test.js
+++ b/tests/loadWorldData.test.js
@@ -5,6 +5,17 @@ import path from 'path';
 import { World } from '../modules/World.js';
 import { loadWorldData } from '../modules/content/loadWorldData.js';
 
+function withFixtureDir(roomsData, itemsData, fn) {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'load-world-data-'));
+    fs.writeFileSync(path.join(fixtureDir, 'rooms.json'), JSON.stringify(roomsData));
+    fs.writeFileSync(path.join(fixtureDir, 'items.json'), JSON.stringify(itemsData));
+    try {
+        return fn(fixtureDir);
+    } finally {
+        fs.rmSync(fixtureDir, { recursive: true, force: true });
+    }
+}
+
 // Loading the real shipped content/ data should produce a working starting
 // room, a second room connected by a real bidirectional exit, and the
 // seeded item in the right room's inventory. This doubles as a regression
@@ -33,19 +44,6 @@ import { loadWorldData } from '../modules/content/loadWorldData.js';
 // pointing at an unknown item key, should be skipped with a warning rather
 // than throwing or silently dropping everything else.
 {
-    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'load-world-data-'));
-    fs.writeFileSync(path.join(fixtureDir, 'rooms.json'), JSON.stringify([
-        {
-            key: 'only-room',
-            name: 'Only Room',
-            description: 'The only room.',
-            isStartingRoom: true,
-            exits: { north: 'nowhere' },
-            items: ['missing-item'],
-        },
-    ]));
-    fs.writeFileSync(path.join(fixtureDir, 'items.json'), JSON.stringify([]));
-
     const world = new World();
     const originalWarn = console.warn;
     const warnings = [];
@@ -53,10 +51,20 @@ import { loadWorldData } from '../modules/content/loadWorldData.js';
 
     let result;
     try {
-        result = loadWorldData(world, fixtureDir);
+        result = withFixtureDir(
+            [{
+                key: 'only-room',
+                name: 'Only Room',
+                description: 'The only room.',
+                isStartingRoom: true,
+                exits: { north: 'nowhere' },
+                items: ['missing-item'],
+            }],
+            [],
+            (fixtureDir) => loadWorldData(world, fixtureDir)
+        );
     } finally {
         console.warn = originalWarn;
-        fs.rmSync(fixtureDir, { recursive: true, force: true });
     }
 
     const onlyRoom = world.getRoomById('only-room');
@@ -65,6 +73,44 @@ import { loadWorldData } from '../modules/content/loadWorldData.js';
     assert.deepStrictEqual(onlyRoom.exits, {}, 'the bad exit reference should be skipped');
     assert.deepStrictEqual(onlyRoom.inventory, [], 'the bad item reference should be skipped');
     assert.ok(warnings.length >= 2, 'both the bad exit and bad item should be warned about');
+}
+
+// Two rooms sharing a key would otherwise silently clobber each other in
+// World's id-keyed Map (and merge their exits/items onto whichever
+// survived) - that's a data integrity error, not a dangling reference, so
+// it must fail loudly instead.
+{
+    const world = new World();
+    assert.throws(
+        () => withFixtureDir(
+            [
+                { key: 'dup', name: 'A Long Hallway', description: 'One.', isStartingRoom: true },
+                { key: 'dup', name: 'Also A Long Hallway', description: 'Two.' },
+            ],
+            [],
+            (fixtureDir) => loadWorldData(world, fixtureDir)
+        ),
+        /Duplicate room key "dup"/,
+        'a duplicate room key should throw rather than silently merge'
+    );
+}
+
+// Same for items: a duplicate key would make the second definition
+// permanently unreachable (items.find always resolves to the first match).
+{
+    const world = new World();
+    assert.throws(
+        () => withFixtureDir(
+            [{ key: 'room-a', name: 'Room A', description: 'A room.', isStartingRoom: true }],
+            [
+                { key: 'dup', name: 'a rusty key', description: 'One.', keywords: ['rusty'] },
+                { key: 'dup', name: 'a shiny key', description: 'Two.', keywords: ['shiny'] },
+            ],
+            (fixtureDir) => loadWorldData(world, fixtureDir)
+        ),
+        /Duplicate item key "dup"/,
+        'a duplicate item key should throw rather than silently shadow'
+    );
 }
 
 console.log('All tests passed');

--- a/tests/loadWorldData.test.js
+++ b/tests/loadWorldData.test.js
@@ -1,0 +1,70 @@
+import assert from 'assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { World } from '../modules/World.js';
+import { loadWorldData } from '../modules/content/loadWorldData.js';
+
+// Loading the real shipped content/ data should produce a working starting
+// room, a second room connected by a real bidirectional exit, and the
+// seeded item in the right room's inventory. This doubles as a regression
+// check that the shipped content files stay valid.
+{
+    const world = new World();
+    const { startingRoomKey } = loadWorldData(world);
+
+    assert.equal(startingRoomKey, 'starting-room');
+
+    const startingRoom = world.getRoomById('starting-room');
+    const hallway = world.getRoomById('narrow-hallway');
+    assert.ok(startingRoom, 'starting room should exist');
+    assert.ok(hallway, 'second room should exist');
+
+    assert.equal(startingRoom.exits.north, hallway.id, 'starting room should exit north into the hallway');
+    assert.equal(hallway.exits.south, startingRoom.id, 'hallway should exit south back to the starting room');
+
+    assert.equal(startingRoom.inventory.length, 1, 'starting room should have the seeded item');
+    const [key] = startingRoom.inventory;
+    assert.equal(key.name, 'a rusty key');
+    assert.deepStrictEqual(key.keywords, ['rusty', 'key']);
+}
+
+// A room exit pointing at an unknown room key, and an item reference
+// pointing at an unknown item key, should be skipped with a warning rather
+// than throwing or silently dropping everything else.
+{
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'load-world-data-'));
+    fs.writeFileSync(path.join(fixtureDir, 'rooms.json'), JSON.stringify([
+        {
+            key: 'only-room',
+            name: 'Only Room',
+            description: 'The only room.',
+            isStartingRoom: true,
+            exits: { north: 'nowhere' },
+            items: ['missing-item'],
+        },
+    ]));
+    fs.writeFileSync(path.join(fixtureDir, 'items.json'), JSON.stringify([]));
+
+    const world = new World();
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args.join(' '));
+
+    let result;
+    try {
+        result = loadWorldData(world, fixtureDir);
+    } finally {
+        console.warn = originalWarn;
+        fs.rmSync(fixtureDir, { recursive: true, force: true });
+    }
+
+    const onlyRoom = world.getRoomById('only-room');
+    assert.equal(result.startingRoomKey, 'only-room');
+    assert.ok(onlyRoom, 'the well-formed room should still load');
+    assert.deepStrictEqual(onlyRoom.exits, {}, 'the bad exit reference should be skipped');
+    assert.deepStrictEqual(onlyRoom.inventory, [], 'the bad item reference should be skipped');
+    assert.ok(warnings.length >= 2, 'both the bad exit and bad item should be warned about');
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
Phase 1 step 4 of the engine-hardening roadmap (see ARCHITECTURE.md's build order) — the last item on the Phase 1 list. Room/item definitions move out of hardcoded JS into `content/rooms.json` and `content/items.json`, loaded at startup by the new `modules/content/loadWorldData.js`, instead of being built inline in `game.js`.

Named `content/`, not `data/`, per the pack layout in ARCHITECTURE.md — `data.js` (character persistence) already owns that name at the repo root. This is effectively "core's" content for now, same framing already used for `modules/commands/index.js`; it moves under a real pack layout once Phase 4 builds one. NPC data isn't handled here — there's no NPC entity/class yet (Phase 3), so there's nothing real to load a shape for.

Previously the Starting Room was hardcoded twice in `game.js`'s login flow, lazily created on first login if missing. Now world data loads once at startup and both login branches just look the room up by its `isStartingRoom`-flagged key.

To actually exercise the format (not just the one room that already existed), seed content also adds a second room with a real bidirectional exit and one item, so rooms/exits/items are all proven end to end — previously no exit had ever been configured anywhere and no item had ever existed in a live room.

`loadWorldData(world, contentDir)` accepts an overridable content directory so tests can point it at fixture data; malformed entries (unknown exit/item references) are logged and skipped rather than crashing the whole load, per the "pack loading is semi-trusted" guardrail in ROADMAP.md. A parse failure on our own core content files still throws — fail loudly at startup rather than silently booting an empty world.

## Testing
- `npm test` — added `tests/loadWorldData.test.js` (loads the real shipped content and checks rooms/exits/items; a fixture-based case for the skip-on-bad-reference path).
- `npm run lint` — clean.
- Manual smoke test against a live server: connect, `look` shows the seeded item, `get` it, move `north` into the new room, `look` again, move `south` back — all working against real data-driven content over a live socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)