### PR TITLE
Buffer socket input by line instead of assuming one line per packet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,3 +121,25 @@ case-insensitive for free (no separate duplicate-rejection logic needed;
 disconnect — see `modules/commands/quit.js`'s `disconnectCharacter`,
 shared by both), not continuously. No autosave/checkpointing yet; revisit
 if that becomes a real pain point rather than building it speculatively.
+
+## Known gap: no input rate/size limiting
+
+`server.js`'s per-connection line buffer (`modules/utils.js`'s
+`extractLines`, added to fix real line-splitting bugs against clients like
+Windows' `telnet.exe`) has no cap on either axis:
+
+- **Command flooding.** A pasted block of many newline-separated commands
+  (e.g. a hundred `north`s) gets fully drained in one synchronous pass of
+  the `"data"` handler's loop — no per-connection rate limit, no cooldown
+  between commands. Functionally identical to sending the same commands
+  one at a time very fast, but without the natural interleaving-with-other-
+  connections that separate packets get from the event loop; a large
+  enough paste can stall the server for everyone during that pass.
+- **Unbounded buffer growth.** Nothing caps how long `socket.lineBuffer`
+  can grow while waiting for a `\n` — a client that sends a large chunk
+  with no newline at all just keeps that string growing.
+
+Deliberately not fixed yet — real user count is 1-2 people who can just be
+careful about what they paste for now. Needs a real design pass (hard cap
+vs. throttle-and-queue, what a client that trips it sees) before opening
+the server up beyond that, not a reflexive fix bolted on here.

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,3 +1,22 @@
+/**
+ * Split accumulated socket input into complete lines, keeping back any
+ * trailing partial line for the next chunk. Needed because TCP makes no
+ * guarantee that a line arrives in one piece: depending on the client (or
+ * the network), a single line can arrive split across multiple packets,
+ * or - as with Windows' telnet.exe talking to a server that does no
+ * Telnet option negotiation - one keystroke per packet.
+ * @param {string} buffer - Previously buffered, not-yet-complete input.
+ * @param {string} chunk - Newly received data.
+ * @returns {{ lines: string[], remainder: string }} Complete, trimmed
+ *   lines ready to process, plus whatever's left over to buffer next time.
+ */
+export function extractLines(buffer, chunk) {
+  const combined = buffer + chunk;
+  const parts = combined.split("\n");
+  const remainder = parts.pop(); // last part has no trailing \n yet - not complete
+  return { lines: parts.map(line => line.trim()), remainder };
+}
+
 export function writeToSocket(socket, message) {
   const formattedMessage = message.charAt(0).toUpperCase() + message.slice(1);
   socket.write(formattedMessage + "\n");

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "node tests/World.test.js && node tests/events.test.js && node tests/components.test.js && node tests/loadWorldData.test.js && node tests/dataStore.test.js && node tests/characterPersistence.test.js && node tests/disconnectCharacter.test.js"
+    "test": "node tests/World.test.js && node tests/events.test.js && node tests/components.test.js && node tests/loadWorldData.test.js && node tests/dataStore.test.js && node tests/characterPersistence.test.js && node tests/disconnectCharacter.test.js && node tests/extractLines.test.js"
   },
   "author": "",
   "license": "MIT",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 import net from "net";
 import { handleCommand, handleDisconnect } from "./game.js";
-import { writeToSocket } from "./modules/utils.js";
+import { writeToSocket, extractLines } from "./modules/utils.js";
 import { Character } from "./modules/Character.js";
 
 // Allow PORT to be overridden via environment variable for deployment flexibility
@@ -9,13 +9,18 @@ const PORT = process.env.PORT || 8484;
 const server = net.createServer((socket) => {
     socket.character = new Character(); // Initialize character state
     socket.character.socket = socket;
+    socket.lineBuffer = ""; // Not-yet-complete input, see extractLines
     writeToSocket(socket, "Welcome to the game! Please enter your character's name:");
 
     socket.on("data", (data) => {
-        const input = data.toString().trim();
-        const response = handleCommand(socket, input);
-        if (response) {
-            writeToSocket(socket, response);
+        const { lines, remainder } = extractLines(socket.lineBuffer, data.toString());
+        socket.lineBuffer = remainder;
+
+        for (const input of lines) {
+            const response = handleCommand(socket, input);
+            if (response) {
+                writeToSocket(socket, response);
+            }
         }
     });
 

--- a/tests/extractLines.test.js
+++ b/tests/extractLines.test.js
@@ -1,0 +1,74 @@
+import assert from 'assert/strict';
+import { extractLines } from '../modules/utils.js';
+
+// A single complete line, LF-terminated
+{
+    const { lines, remainder } = extractLines('', 'hello\n');
+    assert.deepStrictEqual(lines, ['hello']);
+    assert.equal(remainder, '');
+}
+
+// A single complete line, CRLF-terminated (classic telnet) - trim() strips
+// the trailing \r
+{
+    const { lines, remainder } = extractLines('', 'hello\r\n');
+    assert.deepStrictEqual(lines, ['hello']);
+    assert.equal(remainder, '');
+}
+
+// A partial line with no newline yet must not be treated as complete -
+// this is the exact bug: a client sending one keystroke per packet
+// (Windows telnet.exe against a server with no Telnet negotiation) must
+// not have each keystroke processed as its own command
+{
+    const { lines, remainder } = extractLines('', 'hel');
+    assert.deepStrictEqual(lines, []);
+    assert.equal(remainder, 'hel');
+}
+
+// Multiple lines arriving in one chunk
+{
+    const { lines, remainder } = extractLines('', 'foo\nbar\n');
+    assert.deepStrictEqual(lines, ['foo', 'bar']);
+    assert.equal(remainder, '');
+}
+
+// A blank line (user just pressing Enter) is preserved as an empty line,
+// not dropped - the login flow depends on seeing blank input. "bar" here
+// has no trailing \n yet, so it stays buffered rather than being emitted.
+{
+    const { lines, remainder } = extractLines('', 'foo\n\nbar');
+    assert.deepStrictEqual(lines, ['foo', '']);
+    assert.equal(remainder, 'bar');
+}
+
+// A line split across multiple chunks: nothing should be emitted until
+// the newline actually arrives, and the previous remainder must be fed
+// back in as the buffer on the next call
+{
+    const first = extractLines('', 'fo');
+    assert.deepStrictEqual(first.lines, []);
+    assert.equal(first.remainder, 'fo');
+
+    const second = extractLines(first.remainder, 'o\n');
+    assert.deepStrictEqual(second.lines, ['foo']);
+    assert.equal(second.remainder, '');
+}
+
+// Character-at-a-time transmission (the real-world telnet.exe scenario):
+// feeding one character at a time should emit nothing until Enter, then
+// emit exactly one line with the accumulated word
+{
+    let buffer = '';
+    const chunks = ['P', 'e', 'r', 's', 'i', 's', 't', 't', 'e', 's', 't', '\r', '\n'];
+    const allLines = [];
+    for (const chunk of chunks) {
+        const { lines, remainder } = extractLines(buffer, chunk);
+        allLines.push(...lines);
+        buffer = remainder;
+    }
+    assert.deepStrictEqual(allLines, ['Persisttest']);
+    assert.equal(buffer, '');
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
Fixes the bug reported while reviewing #20: connecting with Windows' `telnet.exe` and typing a character name gave a "Names may only contain letters and spaces" error for every single letter typed.

**Root cause:** `server.js` treated every TCP `"data"` event as exactly one complete line of input. That's only true if the client buffers a full line locally and sends it in one shot on Enter (e.g. `nc`, used throughout prior manual testing) — it's not guaranteed by TCP at all, and breaks outright against Windows' `telnet.exe`, which (absent any Telnet option negotiation from our server, since we don't speak real Telnet) sends one keystroke per packet. Each letter typed was hitting `handleCommand` as its own "command."

## Changes
- `modules/utils.js` gains `extractLines(buffer, chunk)`: a pure function that appends new data to whatever's buffered, splits on `\n`, and returns complete trimmed lines plus whatever incomplete tail to keep buffering. Handles CRLF (`trim()` strips the `\r`), multiple lines in one packet, a single line split across packets, and character-at-a-time transmission (nothing is emitted until a newline actually shows up).
- `server.js`'s `"data"` handler now runs every complete line through `handleCommand` instead of the raw chunk, keeping the remainder on `socket.lineBuffer` between calls.

## Testing
- `npm test` — `tests/extractLines.test.js` covers each case directly, including a test that feeds one character at a time and asserts nothing is emitted until the trailing `\r\n` (the literal bug scenario).
- `npm run lint` — clean.
- Manual smoke test against a live server: sent a name/password/description/command one byte per `write()` with small delays (simulating `telnet.exe`'s behavior) — confirmed no spurious rejections and the full login flow completed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)