### PR TITLE
Switch npm test to Node's built-in test runner, add it to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   # Trigger the workflow on push or pull request,
@@ -36,6 +36,25 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
-        
+
       - name: Run Prettier
         run: npm run format
+
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "node tests/World.test.js && node tests/events.test.js && node tests/components.test.js && node tests/loadWorldData.test.js && node tests/dataStore.test.js && node tests/characterPersistence.test.js && node tests/disconnectCharacter.test.js && node tests/extractLines.test.js"
+    "test": "node --test"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
## Summary
`package.json`'s `test` script was 8 hand-chained `node tests/X.test.js && ...` commands, one per file — manually appended every time a test file was added, and about to grow further as Phase 2 adds more. Node's own test runner (`node --test`, stable since Node 20 — CI already targets Node 20) auto-discovers every `*.test.js` file with zero explicit listing, and natively supports running a subset (explicit file path args, or `--test-name-pattern`) — exactly the "index file with optional parameters" idea being discussed, built in, for free.

Verified this works as a drop-in for the existing plain-assert-style test files (no `test()`/`describe()` calls, just top-level asserts that throw on failure) — no rewriting needed. Passing an explicit directory path (`"tests/"` or `"tests"`) to `--test` hit a resolution quirk on this platform; the no-path form (recursive discovery from cwd, which npm scripts already run from) works cleanly and correctly finds only the 8 files under `tests/`, nothing from `node_modules`.

Also: `npm test` has never actually run in CI — `.github/workflows/lint.yml` only ran lint/format. Renamed the workflow to "CI" and added a sibling `run-tests` job now that it's one clean command.

## Testing
- `npm test` — 8/8 pass, exit 0.
- Verified subset-running: `npm test -- tests/World.test.js` runs only that file.
- Verified failure is still loud: temporarily broke an assertion in `tests/World.test.js`, confirmed it's reported as that file failing with a non-zero exit code, then reverted.
- `npm run lint` — clean.
- New CI job will show up in this PR's checks once it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)