### PR TITLE
Add v1 combat: unarmed auto-attack, sessions, kill/disengage/flee

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,6 +162,98 @@ resolver is a deterministic stat-vs-threshold comparison, proving
 dice mechanic nobody's asked for); and migration of characters saved
 before `components.stats` existed.
 
+**Combat: sessions now, round engine and `cemote` parsing planned.** Combat
+is modeled as a session, not a per-character target — target-switching
+mid-fight and multiple simultaneous combatants (one character fighting
+several attackers) rule out storing a single fixed opponent on the
+character itself:
+
+```js
+// core, transient — not persisted across restarts, not a save-state concern
+CombatSession = {
+  id,
+  participants: Map<character, { target, timer }>,
+}
+
+character.components.combat = { sessionId }   // pointer only, like room membership
+```
+
+`resolveAttack(attacker, defender, attackParams)` (`modules/combat/
+resolveAttack.js`) is the core resolution mechanism regardless of how an
+attack gets produced: runs `resolveCheck` (existing checks/stats machinery),
+applies damage to the defender's `vitality`-role stat, emits `attack` (with
+`hit: boolean`) and, on a hit, `damage`. It takes a fully-formed
+`{ statKey, context, damage }` and never asks where that came from — the
+same function will underlie both v1's auto-attack and the planned `cemote`
+parser. *Which* stat keys mean "attacker's roll" and "defender's threshold"
+are core-recognized **roles**, not hardcoded names — `getStatKeyForRole()`
+(already generic, unchanged) is doing the same job it does for `vitality`,
+just for two new role strings (`content/stats/attributes.json` tags
+`strength` as `"offense"`, `dexterity` as `"defense"`). Core's own logic
+(session bookkeeping) never looks these two up itself, unlike `vitality` —
+only the attack producer does, via the same reusable function.
+
+**V1 (built):** unarmed-only — no wielded-weapon concept exists yet (a
+narrow slice of the still-unbuilt equipment/inventory Phase 2 item), so
+`modules/combat/index.js` registers a single always-available unarmed-strike
+producer (`statKey` = the `offense` role, difficulty = the defender's
+`defense` role value, flat 1 damage) via `registerAttackProducer()`
+(`modules/combat/registry.js`, single-slot like the checks resolver).
+`kill <target>` (`modules/commands/kill.js`) starts or joins a session and
+pulls the attacker out of any other fight first (one fight at a time, for
+now); `disengage` removes just the caller (combat continues for whoever's
+left, once m:n is really in play); `flee <north|east|south|west>`
+(`modules/commands/flee.js`) is a disengage plus a move, but only commits to
+either if a valid exit exists that direction — an invalid direction fails
+outright, no disengage happens. A defeated participant (`vitality` role at
+or below 0) is dropped from their session and fires a `defeat` event; the
+session itself ends once fewer than two participants remain alive.
+
+The **round/`pendingActions` engine** described below for the full design
+isn't built yet — v1 simplifies it away because there's nothing to batch or
+wait on: every action is auto-generated, so each participant just gets an
+independent 2-second repeating timer (`modules/combat/session.js`) that
+calls `resolveAttack` directly, instead of a shared round collecting one
+action per side before resolving together. A per-session 5-minute safety
+timeout still exists as a "something's stuck, force-end it" backstop, since
+nothing else guarantees a session terminates. This also means v1 can't
+produce the full design's "mutual knockout in the same round" outcome — each
+timer resolves on its own — that lands with the real round engine, when
+`cemote` needs one anyway to let both sides submit before anything resolves.
+
+The check resolver picked up real (if minimal) randomness for this: a
+uniform -1/0/+1 nudge to the attacker's effective value, meet-or-beat to
+succeed (`modules/checks/index.js`) — with equal stats that's a 2/3 hit
+chance, chosen over a coin-flip because a two-outcome jitter can only ever
+land at 50/50, never the intentionally-uneven split.
+
+*Full design (planned, not built):* `cemote <target> <freeform text>`
+replaces the auto-attack producer for a theme that wants it, submitting into
+the batched round engine described above instead of firing on an
+independent timer. Target is always a structured argument — resolved by
+keyword-match against session participants, the same mechanism `get`/`give`
+already use, defaulting to the sole other participant in a 1:1 fight — and
+is never inferred from the free text. Only the text after the target gets
+scanned, which closes off "matched a keyword near the wrong name" as a bug
+class rather than requiring smarter parsing to work around it. Matching is a
+strict allowlist over whole tokens with explicitly enumerated synonyms
+authored in content (e.g. `"swing"` and `"swings"` recognized, `"swung"`
+deliberately not) rather than stemming — predictable over clever. Verb
+keywords select an attack type; adverb/style keywords apply transient
+modifiers using the existing `{tag, operation, amount}` shape `stats.js`
+already folds. Defense keywords (dodge/block) and utility keywords (stamina
+recovery, etc.) reuse the identical mechanism against a different effect
+target — no new engine concept, just more content.
+
+Not built yet: the round/`pendingActions` batching engine itself; the
+`cemote` lexicon/parser; loot/currency/win-state beyond "combat ends"; a
+wielded-weapon concept (v1 is unarmed-only); m:n-aware re-targeting when
+your target dies mid-fight but others remain (v1 just leaves you idle rather
+than auto-picking a new target — see `session.js`'s note on it); healing/
+regen (a defeated character just stays at 0 `hp` indefinitely, nothing heals
+it back); and room-wide combat spectating (v1's hit/miss/damage messages
+reach only the two combatants directly, not bystanders in the room).
+
 ## Known gap: no input rate/size limiting
 
 `server.js`'s per-connection line buffer (`modules/utils.js`'s

--- a/content/stats/attributes.json
+++ b/content/stats/attributes.json
@@ -1,6 +1,6 @@
 [
-  { "key": "strength", "label": "Strength", "startingValue": 10 },
-  { "key": "dexterity", "label": "Dexterity", "startingValue": 10 },
+  { "key": "strength", "label": "Strength", "startingValue": 10, "role": "offense" },
+  { "key": "dexterity", "label": "Dexterity", "startingValue": 10, "role": "defense" },
   { "key": "constitution", "label": "Constitution", "startingValue": 10 },
   { "key": "intelligence", "label": "Intelligence", "startingValue": 10 },
   { "key": "wisdom", "label": "Wisdom", "startingValue": 10 },

--- a/game.js
+++ b/game.js
@@ -2,6 +2,7 @@ import { World } from "./modules/World.js";
 import { getCommand } from "./modules/commands/registry.js";
 import "./modules/commands/index.js"; // registers the built-in verbs, see index.js
 import "./modules/checks/index.js"; // registers the default check resolver, see index.js
+import "./modules/combat/index.js"; // registers the unarmed attack producer + combat messages, see index.js
 import { emit } from "./modules/events.js";
 import { loadWorldData } from "./modules/content/loadWorldData.js";
 import { loadStatDefinitions, initializeCharacterStats } from "./modules/content/loadStatDefinitions.js";

--- a/modules/checks/index.js
+++ b/modules/checks/index.js
@@ -4,13 +4,18 @@
 // against something real, not left entirely theoretical. A theme pack can
 // register its own resolver the same way, replacing this one.
 //
-// Deliberately deterministic - no dice/randomness. Nothing has asked for
-// a specific dice mechanic yet, and inventing one here would be guessing;
-// this only needs to prove the plumbing (register -> resolveCheck ->
-// delegate with the right values).
+// A small amount of randomness, added for combat (see ARCHITECTURE.md):
+// a uniform -1/0/+1 nudge to the attacker's effective value, meet-or-beat
+// to succeed. With equal stats that's a 2/3 chance of success - enough
+// that a fixed matchup doesn't always land or always whiff, without
+// inventing a real dice mechanic nobody's asked for yet.
 import { registerCheckResolver } from "./registry.js";
+
+function rollJitter() {
+    return Math.floor(Math.random() * 3) - 1; // -1, 0, or +1, uniform
+}
 
 registerCheckResolver(({ value, context }) => {
     const difficulty = context.difficulty ?? 0;
-    return value >= difficulty;
+    return value + rollJitter() >= difficulty;
 });

--- a/modules/combat/index.js
+++ b/modules/combat/index.js
@@ -1,0 +1,55 @@
+// The current combat content pack (see ARCHITECTURE.md's Combat section) -
+// same framing as modules/checks/index.js and modules/commands/index.js:
+// a real, working default so the plumbing (registry, session engine,
+// events) is proven against something, not left theoretical. Moves under
+// a real content pack once Phase 4 builds one.
+//
+// Ships the one attack anyone can throw right now - an unarmed strike -
+// plus the player-facing messages for what an auto-attack did. No
+// wielded-weapon concept yet (see ARCHITECTURE.md's open question on
+// that). v1 messages only reach the two combatants directly, not room
+// bystanders - broadcasting to the room would mean threading `world`
+// through the combat engine just for flavor text, not worth it yet.
+import { registerAttackProducer } from "./registry.js";
+import { getStatKeyForRole } from "../content/loadStatDefinitions.js";
+import { getStatValue } from "../stats.js";
+import { on } from "../events.js";
+import { writeToSocket } from "../utils.js";
+
+const UNARMED_DAMAGE = 1;
+
+registerAttackProducer((attacker, defender) => ({
+    statKey: getStatKeyForRole("offense"),
+    context: { difficulty: getStatValue(defender, getStatKeyForRole("defense")) },
+    damage: UNARMED_DAMAGE,
+}));
+
+on("attack", ({ attacker, defender, hit }) => {
+    if (hit) {
+        return; // the "damage" listener below covers the hit case
+    }
+    if (attacker.socket) {
+        writeToSocket(attacker.socket, `You swing at ${defender.name} and miss.`);
+    }
+    if (defender.socket) {
+        writeToSocket(defender.socket, `${attacker.name} swings at you and misses.`);
+    }
+});
+
+on("damage", ({ attacker, defender, amount }) => {
+    if (attacker.socket) {
+        writeToSocket(attacker.socket, `You hit ${defender.name} for ${amount} damage!`);
+    }
+    if (defender.socket) {
+        writeToSocket(defender.socket, `${attacker.name} hits you for ${amount} damage!`);
+    }
+});
+
+on("defeat", ({ character, defeatedBy }) => {
+    if (character.socket) {
+        writeToSocket(character.socket, "You have been defeated!");
+    }
+    if (defeatedBy.socket) {
+        writeToSocket(defeatedBy.socket, `You have defeated ${character.name}!`);
+    }
+});

--- a/modules/combat/registry.js
+++ b/modules/combat/registry.js
@@ -1,0 +1,30 @@
+// Engine-side attack-producer registry (see ARCHITECTURE.md's Combat
+// section). "How does a participant's action for an auto-attack get
+// produced" is entirely theme-owned - an unarmed strike today, a wielded
+// weapon or parsed cemote text later. Core only ever calls the one
+// registered producer, the same single-slot shape as
+// modules/checks/registry.js's resolver.
+let producer = null;
+
+/**
+ * Register the function that produces an attack's params. Replaces any
+ * previously registered producer.
+ * @param {(attacker: object, defender: object) => { statKey: string, context?: object, damage: number }} fn
+ */
+export function registerAttackProducer(fn) {
+    producer = fn;
+}
+
+/**
+ * Ask the registered producer for the params of an attacker's attack
+ * against a defender.
+ * @param {object} attacker
+ * @param {object} defender
+ * @returns {{ statKey: string, context?: object, damage: number }}
+ */
+export function produceAttack(attacker, defender) {
+    if (!producer) {
+        throw new Error("No attack producer registered (see registerAttackProducer).");
+    }
+    return producer(attacker, defender);
+}

--- a/modules/combat/resolveAttack.js
+++ b/modules/combat/resolveAttack.js
@@ -1,0 +1,32 @@
+// Core combat resolution (see ARCHITECTURE.md's Combat section). Takes a
+// fully-formed attack - which stat to check, what context to hand the
+// check resolver, how much damage a hit does - and doesn't know or care
+// where any of that came from (an auto-attack producer today, parsed
+// cemote text later). The one thing it's allowed to know, same as the
+// rest of core, is that "vitality" is the role damage comes off of.
+import { resolveCheck } from "../checks/registry.js";
+import { getStatKeyForRole } from "../content/loadStatDefinitions.js";
+import { adjustBaseStat } from "../stats.js";
+import { emit } from "../events.js";
+
+/**
+ * Resolve a single attack: attacker vs. defender.
+ * @param {object} attacker
+ * @param {object} defender
+ * @param {{ statKey: string, context?: object, damage: number }} attackParams
+ * @returns {{ hit: boolean, damage?: number }}
+ */
+export function resolveAttack(attacker, defender, attackParams) {
+    const { statKey, context, damage } = attackParams;
+    const hit = resolveCheck(attacker, statKey, context);
+    emit("attack", { attacker, defender, hit });
+
+    if (!hit) {
+        return { hit: false };
+    }
+
+    adjustBaseStat(defender, getStatKeyForRole("vitality"), -damage);
+    emit("damage", { attacker, defender, amount: damage });
+
+    return { hit: true, damage };
+}

--- a/modules/combat/session.js
+++ b/modules/combat/session.js
@@ -1,0 +1,166 @@
+// Core combat session engine (see ARCHITECTURE.md's Combat section).
+// Tracks who's fighting whom and drives each participant's auto-attack
+// timer. Has no opinion about what an attack looks like (that's
+// registry.js's job) or what a defeat/hit/miss should say to a player
+// (that's modules/combat/index.js, listening for the events emitted
+// below) - this file only knows the mechanics: sessions, participants,
+// timers, and the one role (vitality) it needs to know someone's still
+// standing.
+//
+// v1 note: this is a simplified stand-in for the round/pendingActions
+// engine documented in ARCHITECTURE.md. With every action auto-generated
+// (no cemote yet), there's nothing to collect or wait on, so each
+// participant just gets an independent repeating timer instead of a
+// batched round. The full round engine is still the plan once cemote
+// needs multiple sides to submit before anything resolves.
+import { randomUUID } from "crypto";
+import { getStatKeyForRole } from "../content/loadStatDefinitions.js";
+import { getStatValue } from "../stats.js";
+import { produceAttack } from "./registry.js";
+import { resolveAttack } from "./resolveAttack.js";
+import { emit } from "../events.js";
+
+const AUTO_ATTACK_INTERVAL_MS = 2000;
+// A safety net against a stuck session, not a real combat timer - should
+// essentially never fire while everyone's on auto-attack.
+const SESSION_SAFETY_TIMEOUT_MS = 5 * 60 * 1000;
+
+const sessions = new Map(); // id -> session
+
+function isAlive(character) {
+    return getStatValue(character, getStatKeyForRole("vitality")) > 0;
+}
+
+function createSession() {
+    const session = { id: randomUUID(), participants: new Map() };
+    session.safetyTimer = setTimeout(() => {
+        console.error(`Combat session ${session.id} hit its safety timeout - force-ending.`);
+        endSession(session);
+    }, SESSION_SAFETY_TIMEOUT_MS);
+    sessions.set(session.id, session);
+    return session;
+}
+
+/**
+ * @param {object} character
+ * @returns {object|undefined} The character's active session, if any.
+ */
+export function getSession(character) {
+    const sessionId = character.components.combat?.sessionId;
+    return sessionId ? sessions.get(sessionId) : undefined;
+}
+
+function removeParticipant(session, character) {
+    const entry = session.participants.get(character);
+    if (!entry) {
+        return;
+    }
+    clearInterval(entry.timer);
+    session.participants.delete(character);
+    delete character.components.combat;
+}
+
+function addParticipant(session, character, target) {
+    character.components.combat = { sessionId: session.id };
+    const entry = { target, timer: null };
+    session.participants.set(character, entry);
+    entry.timer = setInterval(() => performAutoAttack(session, character), AUTO_ATTACK_INTERVAL_MS);
+}
+
+function performAutoAttack(session, character) {
+    const entry = session.participants.get(character);
+    if (!entry) {
+        return; // removed between ticks (disengaged, session ended)
+    }
+
+    const target = entry.target;
+    if (!isAlive(character) || !isAlive(target)) {
+        // No re-targeting yet if your target's already down (see the m:n
+        // note in ARCHITECTURE.md) - just sit out until the session-end
+        // check below catches up.
+        return;
+    }
+
+    resolveAttack(character, target, produceAttack(character, target));
+
+    if (!isAlive(target)) {
+        removeParticipant(session, target);
+        emit("defeat", { character: target, defeatedBy: character });
+    }
+
+    checkForSessionEnd(session);
+}
+
+function checkForSessionEnd(session) {
+    const living = Array.from(session.participants.keys()).filter(isAlive);
+    if (living.length >= 2) {
+        return;
+    }
+    endSession(session);
+}
+
+function endSession(session) {
+    clearTimeout(session.safetyTimer);
+    const participants = Array.from(session.participants.keys());
+    for (const character of participants) {
+        removeParticipant(session, character);
+    }
+    sessions.delete(session.id);
+    emit("combatEnd", { participants });
+}
+
+/**
+ * Start or join a combat session against a target - the mechanics behind
+ * the `kill` command. If either side is already in a session, the other
+ * joins it rather than starting a separate one; if the attacker was
+ * already fighting someone else, they leave that fight first (one fight
+ * at a time, for now).
+ * @param {object} attacker
+ * @param {object} target
+ * @returns {boolean} Whether combat was actually joined (false if the
+ *   target's already down, or attacker === target).
+ */
+export function engageCombat(attacker, target) {
+    if (attacker === target || !isAlive(target)) {
+        return false;
+    }
+
+    const targetSession = getSession(target);
+    const attackerSession = getSession(attacker);
+    if (attackerSession && attackerSession !== targetSession) {
+        disengageCombat(attacker);
+    }
+
+    const session = targetSession ?? getSession(attacker) ?? createSession();
+
+    if (session.participants.has(attacker)) {
+        session.participants.get(attacker).target = target;
+    } else {
+        addParticipant(session, attacker, target);
+    }
+
+    if (!session.participants.has(target)) {
+        addParticipant(session, target, attacker);
+    }
+
+    return true;
+}
+
+/**
+ * Remove one participant from their active session, if any. Combat
+ * continues for whoever's left, once there's more than one (see the m:n
+ * note in ARCHITECTURE.md - v1 is mostly exercised 1:1, where this just
+ * ends the fight for both sides).
+ * @param {object} character
+ * @returns {boolean} Whether they were actually in a session.
+ */
+export function disengageCombat(character) {
+    const session = getSession(character);
+    if (!session) {
+        return false;
+    }
+
+    removeParticipant(session, character);
+    checkForSessionEnd(session);
+    return true;
+}

--- a/modules/commands/disengage.js
+++ b/modules/commands/disengage.js
@@ -1,0 +1,20 @@
+import { writeToSocket } from "../utils.js";
+import { getSession, disengageCombat } from "../combat/session.js";
+
+export const disengage = (world, args, character) => {
+    const session = getSession(character);
+    if (!session) {
+        return "You aren't fighting anyone.";
+    }
+
+    const others = Array.from(session.participants.keys()).filter(c => c !== character);
+    disengageCombat(character);
+
+    others.forEach(other => {
+        if (other.socket) {
+            writeToSocket(other.socket, `${character.name} disengages from combat.`);
+        }
+    });
+
+    return "You disengage from combat.";
+};

--- a/modules/commands/flee.js
+++ b/modules/commands/flee.js
@@ -1,0 +1,25 @@
+import { getSession, disengageCombat } from "../combat/session.js";
+import { movePlayer } from "./move.js";
+
+const OPPOSITES = { north: "south", south: "north", east: "west", west: "east" };
+
+// A disengage combined with a move - but only if the move is actually
+// possible. An invalid direction fails outright (no disengage happens)
+// rather than pulling someone out of combat with nowhere to go.
+export const flee = (world, args, character) => {
+    const direction = args[0]?.toLowerCase();
+    if (!OPPOSITES[direction]) {
+        return "Flee which direction? (north, south, east, or west)";
+    }
+
+    const room = world.getRoomById(character.roomId);
+    if (!room.exits || !room.exits[direction]) {
+        return "There's no way out that direction - you can't flee that way!";
+    }
+
+    if (getSession(character)) {
+        disengageCombat(character);
+    }
+
+    return movePlayer(world, character, room, direction, OPPOSITES[direction]);
+};

--- a/modules/commands/index.js
+++ b/modules/commands/index.js
@@ -3,10 +3,13 @@
 // registerCommand from registry.js and calling it, without touching this
 // file (see ARCHITECTURE.md).
 import { registerCommand } from "./registry.js";
+import { disengage } from "./disengage.js";
 import { drop } from "./drop.js";
 import { east } from "./east.js";
+import { flee } from "./flee.js";
 import { get } from "./get.js";
 import { give } from "./give.js";
+import { kill } from "./kill.js";
 import { look } from "./look.js";
 import { north } from "./north.js";
 import { quit } from "./quit.js";
@@ -16,10 +19,13 @@ import { tell } from "./tell.js";
 import { west } from "./west.js";
 import { whisper } from "./whisper.js";
 
+registerCommand("disengage", disengage);
 registerCommand("drop", drop);
 registerCommand("east", east);
+registerCommand("flee", flee);
 registerCommand("get", get);
 registerCommand("give", give);
+registerCommand("kill", kill);
 registerCommand("look", look);
 registerCommand("north", north);
 registerCommand("quit", quit);

--- a/modules/commands/kill.js
+++ b/modules/commands/kill.js
@@ -1,0 +1,28 @@
+import { writeToSocket } from "../utils.js";
+import { engageCombat } from "../combat/session.js";
+
+export const kill = (world, args, character) => {
+    const targetName = args.join(" ").toLowerCase();
+    if (!targetName) {
+        return "Kill whom?";
+    }
+
+    const room = world.getRoomById(character.roomId);
+    const target = room.characters.find(
+        char => char !== character && char.keywords.includes(targetName)
+    );
+
+    if (!target) {
+        return "You don't see them here.";
+    }
+
+    if (!engageCombat(character, target)) {
+        return `${target.name} is already defeated.`;
+    }
+
+    if (target.socket) {
+        writeToSocket(target.socket, `${character.name} attacks you!`);
+    }
+
+    return `You attack ${target.name}!`;
+};

--- a/tests/combatSession.test.js
+++ b/tests/combatSession.test.js
@@ -1,0 +1,140 @@
+import assert from 'assert/strict';
+import { mock } from 'node:test';
+import { engageCombat, disengageCombat, getSession } from '../modules/combat/session.js';
+import { registerAttackProducer } from '../modules/combat/registry.js';
+import { registerCheckResolver } from '../modules/checks/registry.js';
+import { loadStatDefinitions } from '../modules/content/loadStatDefinitions.js';
+import { initStat, getStatValue } from '../modules/stats.js';
+
+loadStatDefinitions(); // real content/stats/attributes.json - gives "vitality" -> "hp"
+
+function makeCombatant(name, hp = 10) {
+    const character = { name, components: {} };
+    initStat(character, 'hp', hp);
+    return character;
+}
+
+// Deterministic for the whole file: every attack hits for 1 damage - this
+// file is testing session/timer bookkeeping, not the hit-chance jitter
+// (see defaultCheckResolver.test.js) or attack resolution (see
+// resolveAttack.test.js).
+registerCheckResolver(() => true);
+registerAttackProducer(() => ({ statKey: 'strength', context: {}, damage: 1 }));
+
+// engageCombat starts a shared session for both sides
+{
+    const a = makeCombatant('A');
+    const b = makeCombatant('B');
+    assert.equal(engageCombat(a, b), true);
+    assert.ok(getSession(a));
+    assert.equal(getSession(a), getSession(b), 'both sides should share the same session');
+    disengageCombat(a);
+    disengageCombat(b);
+}
+
+// Can't attack yourself
+{
+    const a = makeCombatant('A');
+    assert.equal(engageCombat(a, a), false);
+    assert.equal(getSession(a), undefined);
+}
+
+// Can't attack an already-defeated target
+{
+    const a = makeCombatant('A');
+    const b = makeCombatant('B', 0);
+    assert.equal(engageCombat(a, b), false);
+    assert.equal(getSession(a), undefined);
+}
+
+// A third party joining an existing fight shares the same session
+{
+    const a = makeCombatant('A');
+    const b = makeCombatant('B');
+    const c = makeCombatant('C');
+    engageCombat(a, b);
+    engageCombat(c, b);
+
+    assert.equal(getSession(a), getSession(c));
+    assert.equal(getSession(a).participants.size, 3);
+
+    disengageCombat(a);
+    disengageCombat(b);
+    disengageCombat(c);
+}
+
+// Attacking someone new pulls you out of whatever fight you were already
+// in - "one fight at a time" for now (see ARCHITECTURE.md's m:n note)
+{
+    const a = makeCombatant('A');
+    const b = makeCombatant('B');
+    const c = makeCombatant('C');
+    engageCombat(a, b);
+    const oldSession = getSession(b);
+    engageCombat(a, c);
+
+    assert.equal(getSession(a), getSession(c));
+    assert.notEqual(getSession(a), oldSession);
+    assert.equal(getSession(b), undefined, 'b should no longer be in a session - a was their only opponent');
+
+    disengageCombat(a);
+    disengageCombat(c);
+}
+
+// disengageCombat removes just the caller; combat ends for whoever's left
+// once fewer than two combatants remain
+{
+    const a = makeCombatant('A');
+    const b = makeCombatant('B');
+    engageCombat(a, b);
+
+    assert.equal(disengageCombat(a), true);
+    assert.equal(getSession(a), undefined);
+    assert.equal(getSession(b), undefined, 'with only b left, combat should end for b too');
+}
+
+// disengageCombat on someone not in combat is a no-op, not an error
+{
+    const a = makeCombatant('A');
+    assert.equal(disengageCombat(a), false);
+}
+
+// Auto-attack: each side's timer independently lands a hit every 2s tick
+{
+    mock.timers.enable({ apis: ['setInterval', 'setTimeout'] });
+
+    const a = makeCombatant('A');
+    const b = makeCombatant('B');
+    engageCombat(a, b);
+
+    mock.timers.tick(2000);
+    assert.equal(getStatValue(a, 'hp'), 9, 'b\'s tick should have hit a');
+    assert.equal(getStatValue(b, 'hp'), 9, 'a\'s tick should have hit b');
+
+    mock.timers.tick(2000);
+    assert.equal(getStatValue(a, 'hp'), 8);
+    assert.equal(getStatValue(b, 'hp'), 8);
+
+    disengageCombat(a);
+    disengageCombat(b);
+    mock.timers.reset();
+}
+
+// Combat ends automatically once a combatant's hp reaches 0
+{
+    mock.timers.enable({ apis: ['setInterval', 'setTimeout'] });
+
+    const a = makeCombatant('A', 100); // will survive
+    const b = makeCombatant('B', 1);   // one hit from defeat
+    engageCombat(a, b);
+
+    mock.timers.tick(2000);
+
+    assert.equal(getStatValue(b, 'hp'), 0);
+    assert.equal(getSession(a), undefined, 'combat should end for the survivor too');
+    assert.equal(getSession(b), undefined);
+
+    mock.timers.reset();
+}
+
+console.log('All tests passed');

--- a/tests/defaultCheckResolver.test.js
+++ b/tests/defaultCheckResolver.test.js
@@ -7,12 +7,43 @@ import { initStat } from '../modules/stats.js';
 // a side effect, which would break checks.test.js's "no resolver
 // registered yet" case if they shared a process/module cache.
 
+function withMockedRandom(value, fn) {
+    const original = Math.random;
+    Math.random = () => value;
+    try {
+        return fn();
+    } finally {
+        Math.random = original;
+    }
+}
+
 const character = { components: {} };
 initStat(character, 'strength', 10);
 
-assert.equal(resolveCheck(character, 'strength', { difficulty: 5 }), true, 'value >= difficulty should succeed');
-assert.equal(resolveCheck(character, 'strength', { difficulty: 10 }), true, 'exactly meeting difficulty should succeed');
-assert.equal(resolveCheck(character, 'strength', { difficulty: 11 }), false, 'value < difficulty should fail');
-assert.equal(resolveCheck(character, 'strength'), true, 'a missing difficulty defaults to 0');
+// The resolver nudges the attacker's value by -1/0/+1 before comparing
+// (see checks/index.js) - difficulties far enough from the base value are
+// deterministic regardless of which nudge lands.
+assert.equal(resolveCheck(character, 'strength', { difficulty: 8 }), true, 'value comfortably above difficulty should always succeed');
+assert.equal(resolveCheck(character, 'strength', { difficulty: 12 }), false, 'value comfortably below difficulty should always fail');
+assert.equal(resolveCheck(character, 'strength'), true, 'a missing difficulty defaults to 0, always succeeds');
+
+// At the boundary (difficulty === value), the three possible nudges are
+// exercised directly by mocking Math.random, rather than relying on many
+// trials landing statistically close to 2/3.
+assert.equal(
+    withMockedRandom(0, () => resolveCheck(character, 'strength', { difficulty: 10 })),
+    false,
+    'a -1 nudge (Math.random() near 0) takes the value below difficulty - miss'
+);
+assert.equal(
+    withMockedRandom(0.5, () => resolveCheck(character, 'strength', { difficulty: 10 })),
+    true,
+    'a 0 nudge (Math.random() near the middle) meets difficulty exactly - hit'
+);
+assert.equal(
+    withMockedRandom(0.99, () => resolveCheck(character, 'strength', { difficulty: 10 })),
+    true,
+    'a +1 nudge (Math.random() near 1) beats difficulty - hit'
+);
 
 console.log('All tests passed');

--- a/tests/loadStatDefinitions.test.js
+++ b/tests/loadStatDefinitions.test.js
@@ -33,6 +33,8 @@ function withFixtureDir(attributesData, fn) {
     ]);
 
     assert.equal(getStatKeyForRole('vitality'), 'hp');
+    assert.equal(getStatKeyForRole('offense'), 'strength');
+    assert.equal(getStatKeyForRole('defense'), 'dexterity');
     assert.equal(getStatDefinition('hp').startingValue, 10);
     assert.equal(getStatDefinition('strength').label, 'Strength');
 }

--- a/tests/resolveAttack.test.js
+++ b/tests/resolveAttack.test.js
@@ -1,0 +1,64 @@
+import assert from 'assert/strict';
+import { resolveAttack } from '../modules/combat/resolveAttack.js';
+import { registerCheckResolver } from '../modules/checks/registry.js';
+import { loadStatDefinitions } from '../modules/content/loadStatDefinitions.js';
+import { initStat, getStatValue } from '../modules/stats.js';
+import { on } from '../modules/events.js';
+
+loadStatDefinitions(); // real content/stats/attributes.json - gives "vitality" -> "hp"
+
+function makeCombatant(hp = 10) {
+    const character = { name: 'Fighter', components: {} };
+    initStat(character, 'hp', hp);
+    return character;
+}
+
+const events = [];
+on('attack', (payload) => events.push(['attack', payload]));
+on('damage', (payload) => events.push(['damage', payload]));
+
+// A hit: damage comes off the vitality-role stat (hp), both "attack" and
+// "damage" events fire, and the raw statKey/context/damage the caller
+// passed are exactly what reaches resolveCheck.
+{
+    events.length = 0;
+    let receivedContext;
+    registerCheckResolver(({ context }) => {
+        receivedContext = context;
+        return true;
+    });
+
+    const attacker = makeCombatant();
+    const defender = makeCombatant();
+    const attackParams = { statKey: 'strength', context: { difficulty: 5 }, damage: 3 };
+
+    const result = resolveAttack(attacker, defender, attackParams);
+
+    assert.deepStrictEqual(result, { hit: true, damage: 3 });
+    assert.equal(getStatValue(defender, 'hp'), 7, 'defender\'s hp should drop by the damage amount');
+    assert.deepStrictEqual(receivedContext, { difficulty: 5 }, 'the context passed in should reach resolveCheck unchanged');
+    assert.deepStrictEqual(events, [
+        ['attack', { attacker, defender, hit: true }],
+        ['damage', { attacker, defender, amount: 3 }],
+    ]);
+}
+
+// A miss: no damage applied, only "attack" fires (with hit: false) - no
+// "damage" event at all.
+{
+    events.length = 0;
+    registerCheckResolver(() => false);
+
+    const attacker = makeCombatant();
+    const defender = makeCombatant();
+
+    const result = resolveAttack(attacker, defender, { statKey: 'strength', context: {}, damage: 3 });
+
+    assert.deepStrictEqual(result, { hit: false });
+    assert.equal(getStatValue(defender, 'hp'), 10, 'a miss should not change the defender\'s hp');
+    assert.deepStrictEqual(events, [
+        ['attack', { attacker, defender, hit: false }],
+    ]);
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
RP-focused emote combat (`cemote`) is the long-term direction, but v1
auto-generates every attack instead - see `ARCHITECTURE.md`'s Combat
section for the full design discussion and what's deferred.

- `content/stats/attributes.json` - strength/dexterity now carry the
  `offense`/`defense` roles, the same core-recognized-role mechanism
  `vitality` already uses. Unlike vitality, core's own logic never looks
  these two up - only the attack producer does, via the same
  `getStatKeyForRole()` - so no core changes were needed for this at all.
- `modules/checks/index.js` - the default resolver now nudges the
  attacker's value by a uniform -1/0/+1 before comparing (meet-or-beat).
  With equal stats that's a 2/3 hit chance; a two-outcome jitter can only
  ever land at 50/50, so this needed the third value to get an
  intentionally uneven split.
- `modules/combat/registry.js` - `registerAttackProducer`/`produceAttack`,
  single-slot like the checks resolver. "How does a participant's action
  get produced" is entirely theme-owned - unarmed strikes today, a
  wielded weapon or parsed `cemote` text later.
- `modules/combat/resolveAttack.js` - the actual resolution mechanism: runs
  `resolveCheck`, applies damage to whichever stat carries the vitality
  role, emits `attack`/`damage`. Takes a fully-formed `attackParams` and
  never asks where it came from.
- `modules/combat/session.js` - session/participant bookkeeping. Sessions
  track participants directly (not per-character targets), since
  target-switching mid-fight and multiple simultaneous combatants rule
  out a fixed opponent on the character. v1 simplifies away the round/
  `pendingActions` batching engine the full `cemote` design needs - with
  every action auto-generated there's nothing to wait on, so each
  participant gets an independent 2-second repeating timer instead. A
  5-minute per-session safety timeout guards against a stuck session.
- `modules/combat/index.js` - the current combat content pack (same
  framing as `checks/index.js`): registers the unarmed-strike producer
  and the attack/damage/defeat message listeners.
- `modules/commands/kill.js`, `disengage.js`, `flee.js` - `kill` starts or
  joins a session and pulls the attacker out of any other fight first
  (one fight at a time, for now); `flee` only disengages if the move
  actually succeeds.

Not built yet (see `ARCHITECTURE.md`): the round/`pendingActions` batching
engine itself, the `cemote` lexicon/parser, a wielded-weapon concept (v1 is
unarmed-only), m:n-aware re-targeting when your target dies mid-fight,
healing/regen, and room-wide combat spectating (messages reach only the
two combatants directly).

Verified live: two characters fighting exchange hits/misses/damage
messages and the fight ends cleanly on defeat.

`tests/resolveAttack.test.js`, `tests/combatSession.test.js` (including
mocked-timer auto-attack ticks via `node:test`'s `mock.timers`) added;
`tests/defaultCheckResolver.test.js` and `tests/loadStatDefinitions.test.js`
updated for the jitter and the new roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)