### PR TITLE
Strip Telnet negotiation bytes; send CRLF instead of bare LF

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,3 +1,58 @@
+const IAC = 0xff; // Telnet "Interpret As Command" marker (RFC 854)
+const SB = 0xfa; // Begin subnegotiation (e.g. NAWS window-size updates)
+const SE = 0xf0; // End subnegotiation
+
+/**
+ * Strip Telnet option-negotiation sequences out of raw incoming bytes.
+ * This server speaks plain text, not the Telnet protocol - it never
+ * replies to a negotiation request - but clients connecting in Telnet
+ * mode (PuTTY's default) send some regardless (WILL/DO for terminal type,
+ * NAWS on connect and on every window resize, etc). Left unstripped, those
+ * bytes land in whatever's typed next: often invisible to the user, but
+ * enough to fail e.g. the character-name allowlist on the very first
+ * login attempt. Must run on the raw Buffer, before any toString(): IAC
+ * bytes (0xFF) aren't valid UTF-8 on their own, so decoding first would
+ * mangle them into replacement characters instead of a recognizable
+ * pattern to strip.
+ *
+ * Deliberately a strip-and-ignore filter, not a real Telnet implementation
+ * - it doesn't negotiate anything back, and (like extractLines historically
+ * did for \n) it assumes a negotiation sequence doesn't get split across
+ * two "data" chunks. Both are fine for this project's real client mix; see
+ * ARCHITECTURE.md's "Known gap" note for the same tradeoff made elsewhere.
+ * @param {Buffer} data
+ * @returns {Buffer}
+ */
+export function stripTelnetNegotiation(data) {
+  const output = [];
+  let i = 0;
+  while (i < data.length) {
+    if (data[i] !== IAC) {
+      output.push(data[i]);
+      i++;
+      continue;
+    }
+
+    const command = data[i + 1];
+    if (command === IAC) {
+      output.push(IAC); // IAC IAC is an escaped literal 0xFF byte
+      i += 2;
+    } else if (command === SB) {
+      // Subnegotiation: skip everything up to and including the closing IAC SE
+      let j = i + 2;
+      while (j < data.length - 1 && !(data[j] === IAC && data[j + 1] === SE)) {
+        j++;
+      }
+      i = j + 2;
+    } else if (command >= 0xfb && command <= 0xfe) {
+      i += 3; // WILL/WONT/DO/DONT + one option byte
+    } else {
+      i += 2; // Other single-byte commands (NOP, GA, ...), or a truncated IAC at chunk end
+    }
+  }
+  return Buffer.from(output);
+}
+
 /**
  * Split accumulated socket input into complete lines, keeping back any
  * trailing partial line for the next chunk. Needed because TCP makes no
@@ -19,7 +74,12 @@ export function extractLines(buffer, chunk) {
 
 export function writeToSocket(socket, message) {
   const formattedMessage = message.charAt(0).toUpperCase() + message.slice(1);
-  socket.write(formattedMessage + "\n");
+  // CRLF, not bare LF: a raw/telnet-mode terminal (e.g. PuTTY) moves down a
+  // line on LF but doesn't return to column 0 without an accompanying CR,
+  // producing a "staircase" where each line starts where the last one
+  // ended. Normalize any internal \n too (multi-line messages like the
+  // room-description text build those directly), not just the trailing one.
+  socket.write(formattedMessage.replace(/\n/g, "\r\n") + "\r\n");
 }
 
 export function broadcast(room, message, excludeSocket = null) {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 import net from "net";
 import { handleCommand, handleDisconnect } from "./game.js";
-import { writeToSocket, extractLines } from "./modules/utils.js";
+import { writeToSocket, extractLines, stripTelnetNegotiation } from "./modules/utils.js";
 import { Character } from "./modules/Character.js";
 
 // Allow PORT to be overridden via environment variable for deployment flexibility
@@ -13,7 +13,8 @@ const server = net.createServer((socket) => {
     writeToSocket(socket, "Welcome to the game! Please enter your character's name:");
 
     socket.on("data", (data) => {
-        const { lines, remainder } = extractLines(socket.lineBuffer, data.toString());
+        const cleaned = stripTelnetNegotiation(data);
+        const { lines, remainder } = extractLines(socket.lineBuffer, cleaned.toString());
         socket.lineBuffer = remainder;
 
         for (const input of lines) {

--- a/tests/stripTelnetNegotiation.test.js
+++ b/tests/stripTelnetNegotiation.test.js
@@ -1,0 +1,58 @@
+import assert from 'assert/strict';
+import { stripTelnetNegotiation } from '../modules/utils.js';
+
+// Plain text with no negotiation bytes passes through unchanged
+{
+    const result = stripTelnetNegotiation(Buffer.from('hello\n'));
+    assert.equal(result.toString(), 'hello\n');
+}
+
+// A single WILL/WONT/DO/DONT negotiation (IAC + command + option, 3 bytes)
+// is stripped, real text around it survives
+{
+    // IAC WILL ECHO (0xFF 0xFB 0x01), then the user's actual input
+    const data = Buffer.concat([
+        Buffer.from([0xff, 0xfb, 0x01]),
+        Buffer.from('Rhaehan\r\n'),
+    ]);
+    assert.equal(stripTelnetNegotiation(data).toString(), 'Rhaehan\r\n');
+}
+
+// Multiple negotiations back-to-back (the realistic PuTTY-on-connect case)
+{
+    const data = Buffer.concat([
+        Buffer.from([0xff, 0xfb, 0x18]), // IAC WILL TERMINAL-TYPE
+        Buffer.from([0xff, 0xfb, 0x1f]), // IAC WILL NAWS
+        Buffer.from([0xff, 0xfd, 0x01]), // IAC DO ECHO
+        Buffer.from('Rhaehan\r\n'),
+    ]);
+    assert.equal(stripTelnetNegotiation(data).toString(), 'Rhaehan\r\n');
+}
+
+// A subnegotiation block (IAC SB ... IAC SE) is skipped as a whole, e.g. a
+// NAWS window-size report sent mid-session on a terminal resize
+{
+    const data = Buffer.concat([
+        Buffer.from('before'),
+        Buffer.from([0xff, 0xfa, 0x1f, 0x00, 0x50, 0x00, 0x18, 0xff, 0xf0]), // IAC SB NAWS <w><h> IAC SE
+        Buffer.from('after\n'),
+    ]);
+    assert.equal(stripTelnetNegotiation(data).toString(), 'beforeafter\n');
+}
+
+// IAC IAC is an escaped literal 0xFF byte, not a command - it should
+// survive as a single 0xFF, not be stripped
+{
+    const data = Buffer.from([0xff, 0xff]);
+    const result = stripTelnetNegotiation(data);
+    assert.deepStrictEqual([...result], [0xff]);
+}
+
+// A truncated IAC at the very end of a chunk (no command byte yet) doesn't
+// throw or hang - it's just dropped
+{
+    const data = Buffer.concat([Buffer.from('hi'), Buffer.from([0xff])]);
+    assert.doesNotThrow(() => stripTelnetNegotiation(data));
+}
+
+console.log('All tests passed');

--- a/tests/writeToSocket.test.js
+++ b/tests/writeToSocket.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert/strict';
+import { writeToSocket } from '../modules/utils.js';
+
+function captureWrite() {
+    let written = '';
+    const socket = { write: (data) => { written += data; } };
+    return { socket, get: () => written };
+}
+
+// A single-line message gets a trailing CRLF, not a bare LF - a raw/telnet
+// terminal (e.g. PuTTY) needs the CR to return to column 0
+{
+    const { socket, get } = captureWrite();
+    writeToSocket(socket, 'hello');
+    assert.equal(get(), 'Hello\r\n');
+}
+
+// Internal newlines (multi-line messages like a room description) are
+// normalized to CRLF too, not just the trailing one
+{
+    const { socket, get } = captureWrite();
+    writeToSocket(socket, 'first line\nsecond line');
+    assert.equal(get(), 'First line\r\nsecond line\r\n');
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
Two client-compatibility bugs surfaced by playtesting over PuTTY, same root
cause: this server speaks plain text over TCP, not the Telnet protocol, and
never did any negotiation or line-ending handling for clients that expect
it.

- A Telnet-mode client (PuTTY's default) sends IAC option-negotiation bytes
  (`WILL TERMINAL-TYPE`, `WILL NAWS`, ...) right after connecting.
  Unstripped, those bytes land in front of whatever's typed next - often
  invisible, but enough to fail the character-name allowlist on the very
  first login attempt (retyping the same name then works, since the
  negotiation only arrives once). `stripTelnetNegotiation()` runs on the
  raw `Buffer` before `extractLines` ever sees it - has to be
  pre-`toString()`, since IAC (`0xFF`) isn't valid UTF-8 on its own and
  would already be mangled into replacement characters by the time it
  reached a string. Deliberately a strip-and-ignore filter, not a real
  Telnet implementation: doesn't negotiate anything back, and (like
  `extractLines` historically did for `\n`) assumes a negotiation sequence
  doesn't split across two `"data"` chunks - fine for this project's real
  client mix, same tradeoff already made elsewhere per `ARCHITECTURE.md`'s
  "Known gap" note. Wired into every `"data"` event in `server.js`, not
  just on connect, since a client can send more negotiation later (e.g.
  NAWS again on a terminal resize).
- `writeToSocket()` sent a bare `"\n"`. A raw/telnet-mode terminal moves
  down a line on LF but doesn't return to column 0 without an accompanying
  CR, so every line of output started where the previous one ended instead
  of at the left margin. Now normalizes to `"\r\n"`, including any internal
  `\n` in a multi-line message (e.g. a room description), not just the
  trailing one.

Verified against the real server: a simulated PuTTY connection (fake IAC
negotiation immediately followed by a valid name) is now accepted on the
first attempt instead of failing the name allowlist.

`tests/stripTelnetNegotiation.test.js`, `tests/writeToSocket.test.js` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)