### PR TITLE
Add passive vitality regen and room-wide combat messages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -245,14 +245,31 @@ already folds. Defense keywords (dodge/block) and utility keywords (stamina
 recovery, etc.) reuse the identical mechanism against a different effect
 target — no new engine concept, just more content.
 
+**Regen and room-wide messages (built).** `modules/combat/regen.js`'s
+`startRegenTicker(world)` (called once from `game.js`) heals every online
+character's `vitality`-role stat by a flat 1 every 30 seconds, capped at
+that stat's content-defined `startingValue` — the closest thing to a "max
+hp" that exists, since the stats system has no separate current/max split
+(base *is* current). Deliberately unconditional: same rate whether a
+character is mid-fight, defeated, or just standing around, no "resting
+heals faster" concept yet. This is what keeps a defeated character (`hp`
+at 0) from staying there forever.
+
+`modules/combat/index.js`'s attack/damage/defeat listeners now also
+broadcast a third-person version of each message to bystanders in the
+combatants' room (`writeToSocket` to everyone there except the two direct
+participants, who already got their own message). Reaching bystanders
+needs a room lookup by `character.roomId`, which needs `world` — threaded
+in via `setWorld(world)`, called once from `game.js` alongside
+`startRegenTicker`, rather than passed through every call site between a
+timer tick and the listener. Assumes both combatants share a room, true
+for every way v1 can start or continue a fight.
+
 Not built yet: the round/`pendingActions` batching engine itself; the
 `cemote` lexicon/parser; loot/currency/win-state beyond "combat ends"; a
-wielded-weapon concept (v1 is unarmed-only); m:n-aware re-targeting when
-your target dies mid-fight but others remain (v1 just leaves you idle rather
-than auto-picking a new target — see `session.js`'s note on it); healing/
-regen (a defeated character just stays at 0 `hp` indefinitely, nothing heals
-it back); and room-wide combat spectating (v1's hit/miss/damage messages
-reach only the two combatants directly, not bystanders in the room).
+wielded-weapon concept (v1 is unarmed-only); and m:n-aware re-targeting
+when your target dies mid-fight but others remain (v1 just leaves you idle
+rather than auto-picking a new target — see `session.js`'s note on it).
 
 ## Known gap: no input rate/size limiting
 

--- a/game.js
+++ b/game.js
@@ -2,7 +2,8 @@ import { World } from "./modules/World.js";
 import { getCommand } from "./modules/commands/registry.js";
 import "./modules/commands/index.js"; // registers the built-in verbs, see index.js
 import "./modules/checks/index.js"; // registers the default check resolver, see index.js
-import "./modules/combat/index.js"; // registers the unarmed attack producer + combat messages, see index.js
+import { setWorld as setCombatWorld } from "./modules/combat/index.js"; // registers the unarmed attack producer + combat messages, see index.js
+import { startRegenTicker } from "./modules/combat/regen.js";
 import { emit } from "./modules/events.js";
 import { loadWorldData } from "./modules/content/loadWorldData.js";
 import { loadStatDefinitions, initializeCharacterStats } from "./modules/content/loadStatDefinitions.js";
@@ -13,6 +14,8 @@ import { characterExists, loadCharacterState, saveCharacterState } from "./data.
 const world = new World(); // Initialize the world
 const { startingRoomKey } = loadWorldData(world); // Load room/item content data
 loadStatDefinitions(); // Load stat definitions (which stats exist, starting values, roles)
+setCombatWorld(world); // let combat messages reach room bystanders, not just the two combatants
+startRegenTicker(world); // passive vitality regen for every online character
 
 // Letters and spaces only: character names become part of a filesystem
 // path (see data.js), so this is a real allowlist, not just cosmetic.

--- a/modules/World.js
+++ b/modules/World.js
@@ -75,4 +75,14 @@ export class World {
         }
         return null;
     }
+
+    /**
+     * All currently-connected characters, across every room.
+     * @returns {object[]}
+     */
+    getOnlineCharacters() {
+        return Array.from(this.rooms.values()).flatMap(
+            (room) => room.characters.filter((char) => char.socket)
+        );
+    }
 }

--- a/modules/combat/index.js
+++ b/modules/combat/index.js
@@ -7,9 +7,8 @@
 // Ships the one attack anyone can throw right now - an unarmed strike -
 // plus the player-facing messages for what an auto-attack did. No
 // wielded-weapon concept yet (see ARCHITECTURE.md's open question on
-// that). v1 messages only reach the two combatants directly, not room
-// bystanders - broadcasting to the room would mean threading `world`
-// through the combat engine just for flavor text, not worth it yet.
+// that). Requires setWorld() (called once from game.js) to reach room
+// bystanders - the two combatants get their direct messages regardless.
 import { registerAttackProducer } from "./registry.js";
 import { getStatKeyForRole } from "../content/loadStatDefinitions.js";
 import { getStatValue } from "../stats.js";
@@ -24,6 +23,36 @@ registerAttackProducer((attacker, defender) => ({
     damage: UNARMED_DAMAGE,
 }));
 
+let world = null;
+
+/**
+ * Give this module a way to resolve a combatant's room, so combat
+ * messages can reach bystanders instead of just the two direct
+ * participants. Call once at startup (see game.js); the "attack"/
+ * "damage"/"defeat" listeners below no-op the bystander broadcast if
+ * this was never called (e.g. in tests that exercise them standalone).
+ * @param {import("../World.js").World} w
+ */
+export function setWorld(w) {
+    world = w;
+}
+
+// Bystander version of a combat message, sent to everyone else in the
+// room a combatant is standing in (both combatants already got their own
+// direct message, so they're excluded). Assumes the two combatants share
+// a room, true for every way v1 can start or continue a fight.
+function broadcastToRoom(character, message, exclude) {
+    const room = world?.getRoomById(character.roomId);
+    if (!room) {
+        return;
+    }
+    for (const bystander of room.characters) {
+        if (!exclude.includes(bystander) && bystander.socket) {
+            writeToSocket(bystander.socket, message);
+        }
+    }
+}
+
 on("attack", ({ attacker, defender, hit }) => {
     if (hit) {
         return; // the "damage" listener below covers the hit case
@@ -34,6 +63,7 @@ on("attack", ({ attacker, defender, hit }) => {
     if (defender.socket) {
         writeToSocket(defender.socket, `${attacker.name} swings at you and misses.`);
     }
+    broadcastToRoom(attacker, `${attacker.name} swings at ${defender.name} and misses.`, [attacker, defender]);
 });
 
 on("damage", ({ attacker, defender, amount }) => {
@@ -43,6 +73,7 @@ on("damage", ({ attacker, defender, amount }) => {
     if (defender.socket) {
         writeToSocket(defender.socket, `${attacker.name} hits you for ${amount} damage!`);
     }
+    broadcastToRoom(attacker, `${attacker.name} hits ${defender.name} for ${amount} damage!`, [attacker, defender]);
 });
 
 on("defeat", ({ character, defeatedBy }) => {
@@ -52,4 +83,5 @@ on("defeat", ({ character, defeatedBy }) => {
     if (defeatedBy.socket) {
         writeToSocket(defeatedBy.socket, `You have defeated ${character.name}!`);
     }
+    broadcastToRoom(character, `${defeatedBy.name} has defeated ${character.name}!`, [character, defeatedBy]);
 });

--- a/modules/combat/regen.js
+++ b/modules/combat/regen.js
@@ -1,0 +1,42 @@
+// Passive vitality regeneration (see ARCHITECTURE.md's Combat section).
+// Nothing else heals a character back - a defeated participant just sits
+// at 0 `hp` indefinitely otherwise - so this is a flat, unconditional
+// trickle: same rate for everyone, in or out of combat, no "resting heals
+// faster" or "regen pauses mid-fight" concept yet. Deliberately the
+// simplest thing that gives regen a floor to iterate on later.
+import { getStatKeyForRole, getStatDefinition } from "../content/loadStatDefinitions.js";
+import { getStatValue, adjustBaseStat } from "../stats.js";
+
+const REGEN_INTERVAL_MS = 30 * 1000;
+const REGEN_AMOUNT = 1;
+
+/**
+ * Start the global regen ticker: every REGEN_INTERVAL_MS, every online
+ * character's vitality-role stat heals by REGEN_AMOUNT, capped at that
+ * stat's defined starting value. That cap is a v1 stand-in for a real
+ * max-vitality concept - there's no separate "current vs. max hp" split
+ * anywhere else in the stats system yet (base *is* current), so the
+ * content-defined starting value is the closest thing to "full health"
+ * available to key off.
+ * @param {import("../World.js").World} world
+ * @returns {NodeJS.Timeout} The interval handle (e.g. for tests to clear).
+ */
+export function startRegenTicker(world) {
+    return setInterval(() => regenTick(world), REGEN_INTERVAL_MS);
+}
+
+function regenTick(world) {
+    const key = getStatKeyForRole("vitality");
+    if (!key) {
+        return;
+    }
+
+    const max = getStatDefinition(key).startingValue;
+    for (const character of world.getOnlineCharacters()) {
+        const current = getStatValue(character, key);
+        if (current === undefined || current >= max) {
+            continue;
+        }
+        adjustBaseStat(character, key, Math.min(REGEN_AMOUNT, max - current));
+    }
+}

--- a/tests/combatBroadcast.test.js
+++ b/tests/combatBroadcast.test.js
@@ -1,0 +1,68 @@
+import assert from 'assert/strict';
+import { World } from '../modules/World.js';
+import { loadStatDefinitions } from '../modules/content/loadStatDefinitions.js';
+import { initStat } from '../modules/stats.js';
+import { emit } from '../modules/events.js';
+import { setWorld } from '../modules/combat/index.js'; // also registers the attack producer + message listeners
+
+loadStatDefinitions();
+
+function makeCharacter(name) {
+    const written = [];
+    const character = { name, components: {}, socket: { written, write: (msg) => written.push(msg) } };
+    initStat(character, 'hp', 10);
+    return character;
+}
+
+function lastMessage(character) {
+    return character.socket.written[character.socket.written.length - 1];
+}
+
+const world = new World();
+const room = world.getRoomById(world.addRoom('Arena', 'A place to fight'));
+
+const attacker = makeCharacter('Attacker');
+const defender = makeCharacter('Defender');
+const bystander = makeCharacter('Bystander');
+[attacker, defender, bystander].forEach(c => room.addCharacter(c));
+
+setWorld(world);
+
+// A miss reaches a room bystander too, in third person
+{
+    emit('attack', { attacker, defender, hit: false });
+    assert.match(lastMessage(bystander), /Attacker swings at Defender and misses\./);
+}
+
+// A hit's damage message reaches a room bystander too
+{
+    emit('damage', { attacker, defender, amount: 3 });
+    assert.match(lastMessage(bystander), /Attacker hits Defender for 3 damage!/);
+}
+
+// A defeat reaches a room bystander too
+{
+    emit('defeat', { character: defender, defeatedBy: attacker });
+    assert.match(lastMessage(bystander), /Attacker has defeated Defender!/);
+}
+
+// The two direct combatants get exactly their own personal message, not a
+// second, duplicate bystander one
+{
+    const beforeAttacker = attacker.socket.written.length;
+    const beforeDefender = defender.socket.written.length;
+
+    emit('attack', { attacker, defender, hit: false });
+
+    assert.equal(attacker.socket.written.length, beforeAttacker + 1, 'attacker gets exactly one message');
+    assert.equal(defender.socket.written.length, beforeDefender + 1, 'defender gets exactly one message');
+}
+
+// Without setWorld ever being called, the bystander broadcast just no-ops
+// instead of throwing - other tests exercise combat events standalone.
+{
+    setWorld(null);
+    assert.doesNotThrow(() => emit('attack', { attacker, defender, hit: false }));
+}
+
+console.log('All tests passed');

--- a/tests/regen.test.js
+++ b/tests/regen.test.js
@@ -1,0 +1,78 @@
+import assert from 'assert/strict';
+import { mock } from 'node:test';
+import { World } from '../modules/World.js';
+import { loadStatDefinitions } from '../modules/content/loadStatDefinitions.js';
+import { initStat, getStatValue } from '../modules/stats.js';
+import { startRegenTicker } from '../modules/combat/regen.js';
+
+loadStatDefinitions(); // real content/stats/attributes.json - "vitality" -> "hp", startingValue 10
+
+function makeCharacter(name, hp, online = true) {
+    const character = { name, components: {}, socket: online ? {} : null };
+    initStat(character, 'hp', hp);
+    return character;
+}
+
+function makeRoomWith(world, ...characters) {
+    const room = world.getRoomById(world.addRoom('Room', 'A room'));
+    characters.forEach(c => room.addCharacter(c));
+    return room;
+}
+
+// Online characters regen by 1 every 30s; offline ones (no socket) don't
+{
+    mock.timers.enable({ apis: ['setInterval'] });
+
+    const world = new World();
+    const online = makeCharacter('Online', 5);
+    const offline = makeCharacter('Offline', 5, false);
+    makeRoomWith(world, online, offline);
+
+    const handle = startRegenTicker(world);
+    mock.timers.tick(30000);
+
+    assert.equal(getStatValue(online, 'hp'), 6, 'online character should regen');
+    assert.equal(getStatValue(offline, 'hp'), 5, 'offline character should not regen');
+
+    clearInterval(handle);
+    mock.timers.reset();
+}
+
+// Capped at the stat's defined starting value - never overshoots
+{
+    mock.timers.enable({ apis: ['setInterval'] });
+
+    const world = new World();
+    const full = makeCharacter('Full', 10); // already at the starting value
+    makeRoomWith(world, full);
+
+    const handle = startRegenTicker(world);
+    mock.timers.tick(30000);
+
+    assert.equal(getStatValue(full, 'hp'), 10, 'should not exceed the starting-value cap');
+
+    clearInterval(handle);
+    mock.timers.reset();
+}
+
+// Keeps healing tick over tick, then holds once it hits the cap
+{
+    mock.timers.enable({ apis: ['setInterval'] });
+
+    const world = new World();
+    const recovering = makeCharacter('Recovering', 8);
+    makeRoomWith(world, recovering);
+
+    const handle = startRegenTicker(world);
+    mock.timers.tick(30000);
+    assert.equal(getStatValue(recovering, 'hp'), 9);
+    mock.timers.tick(30000);
+    assert.equal(getStatValue(recovering, 'hp'), 10);
+    mock.timers.tick(30000);
+    assert.equal(getStatValue(recovering, 'hp'), 10, 'stays capped once at the starting value');
+
+    clearInterval(handle);
+    mock.timers.reset();
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Everyone regens 1 hp per 30s (`modules/combat/regen.js`), capped at their stat's content-defined `startingValue` since there's no separate max-hp concept yet. Unconditional — same rate in or out of combat — so a defeated character (stuck at 0 hp) isn't stuck there forever.
- Combat's attack/damage/defeat messages now also reach bystanders in the combatants' room, not just the two direct participants. Needs a world reference to resolve a room by `character.roomId`, threaded in via a new `setWorld()` called once from `game.js`.
- `ARCHITECTURE.md` updated to move both out of the combat section's "not built yet" list and document the design calls (max-hp cap, unconditional regen, room-lookup wiring).

## Test plan
- `npm test` — 20 tests pass, including two new files: `tests/regen.test.js` (tick rate, cap, offline characters excluded) and `tests/combatBroadcast.test.js` (bystander messages, no double-messaging combatants, no-op when `setWorld` was never called).
- `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)