### PR TITLE
Add ordinal/cardinal item keyword qualifiers: 2.pouch, 3*brick

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -357,6 +357,52 @@ every command in the codebase already uses for its own actor-facing
 line. Wants its own pass across all of them once it's worth doing, not a
 one-off fix here.
 
+## Item qualifiers: ordinal (2.x) and cardinal (N*x) keyword matching
+
+`modules/itemSearch.js`'s `resolveItemToken` replaces the ad-hoc
+`items.find(i => i.keywords.includes(keyword))` that `get`/`put`/`drop`/
+`give`/`look`/`items`/`emote`'s `#` all used to duplicate, and adds two
+optional qualifiers on top of a plain keyword: `2.pouch` (ordinal - the
+2nd match) and `3*brick` (cardinal - the first 3 matches). Both reduce to
+the same question - "are there at least N matches for this keyword, in
+this search scope?" - so the resolver finds every match once, in the
+same priority order each command already searched in (inventory then
+room, etc.), then either indexes into it or takes its front slice.
+Plain, unqualified keywords are unchanged: first match, same as before.
+
+**Fail the whole command, not a partial one.** Asking for more than
+exists - `2.pouch` with only one around, `3*brick` with only two -
+rejects the entire command with `There aren't N things matching "x"
+here.`, nothing moved. `put` extends this to a batch capacity check:
+`canContainAll` (`modules/containers.js`) weighs the *whole* batch
+cumulatively against a container's budget before moving anything, not
+each item against the container's still-empty current state one at a
+time - three items that individually fit a container can still
+collectively overflow it. `canContain` is now just `canContainAll` for a
+single item, so single-item and batch puts share one code path.
+
+**Grouped `"xN"` phrasing for multi-item messages**, not pluralization:
+`You pick up a 0.5 lb brick (x3).` Item names already carry their own
+article (`a 0.5 lb brick`), which naive pluralization can't handle in
+general (irregular nouns) without content opting in per item, and a
+cardinal match isn't even guaranteed to be N of the *same* item -
+`3*brick` can pull a mix of different brick weights, all matching
+`"brick"`. `formatItemList` groups by name (`a 0.5 lb brick (x2), a 1 lb
+brick, and a pouch`) instead, which stays correct either way.
+
+**Scoped to items only.** `@` character targeting (in `emote`, `give`'s
+recipient, `whisper`) has no ordinal/cardinal support yet - a separate
+decision if it turns out useful, not assumed here.
+
+**One extra wrinkle for `emote`, spelled out because the two look
+similar:** an *unqualified* `#`/`@` that finds nothing still falls back
+to `"something"`/`"someone"` and the emote proceeds - a typo in
+otherwise-fine freeform text shouldn't nuke the whole thing (existing
+behavior, unchanged). A *qualified* `#` that can't be satisfied aborts
+the entire emote instead - nothing broadcasts, same atomic-failure rule
+as everywhere else - because that's a specific, deliberate request that
+plainly can't be met, not a vague reference worth papering over.
+
 ## Known gap: no input rate/size limiting
 
 `server.js`'s per-connection line buffer (`modules/utils.js`'s

--- a/modules/commands/drop.js
+++ b/modules/commands/drop.js
@@ -1,35 +1,35 @@
 import { writeToSocket } from "../utils.js";
+import { resolveItemToken, formatItemList } from "../itemSearch.js";
 
 export const drop = (world, args, character) => {
-    const keyword = args[0];
+    const itemToken = args[0];
     const room = world.getRoomById(character.roomId);
 
-    if (!keyword) {
+    if (!itemToken) {
         return "What do you want to drop?";
     }
 
-    // Search the player's inventory for the item
-    const itemIndex = character.inventory.findIndex(item =>
-        item.keywords.includes(keyword)
-    );
-
-    if (itemIndex === -1) {
+    const { matches, error } = resolveItemToken(itemToken, [character.inventory]);
+    if (error) {
+        return error;
+    }
+    if (matches.length === 0) {
         return "You can't find that.";
     }
 
-    // Move the item to the room's inventory
-    const [item] = character.inventory.splice(itemIndex, 1);
-    room.inventory.push(item);
+    for (const { item, source } of matches) {
+        source.splice(source.indexOf(item), 1);
+        room.inventory.push(item);
+    }
+
+    const message = formatItemList(matches.map(m => m.item));
 
     // Broadcast the action to the room
     room.characters.forEach(char => {
         if (char !== character && char.socket) {
-            writeToSocket(
-                char.socket,
-                `${character.name} drops ${item.name}.`
-            );
+            writeToSocket(char.socket, `${character.name} drops ${message}.`);
         }
     });
 
-    return `You drop ${item.name}.`;
+    return `You drop ${message}.`;
 };

--- a/modules/commands/emote.js
+++ b/modules/commands/emote.js
@@ -1,4 +1,5 @@
 import { writeToSocket } from "../utils.js";
+import { resolveItemToken, formatItemList } from "../itemSearch.js";
 
 // `emote <text>` - freeform third-person action text: "Character <text>."
 // to the room, "You <text>." back to the actor. Same trailing-period rule
@@ -10,13 +11,25 @@ import { writeToSocket } from "../utils.js";
 // Targeting: a token starting with @ names a character (by keyword,
 // searched in the room), a token starting with # names an item (by
 // keyword, searched in the actor's inventory, then the room floor - same
-// order look.js/put.js already search in). Both resolve to that entity's
-// real name in the broadcast text; an unresolved @ falls back to
-// "someone", an unresolved # to "something", rather than failing the
-// whole emote over one bad keyword. This is a separate, simpler mechanism
-// from the planned cemote parser (see ARCHITECTURE.md's Combat section) -
-// inline references anywhere in free text, not a leading structured
-// target argument plus a verb/modifier keyword lexicon.
+// order look.js/put.js already search in), including their 2.x/N*x
+// qualifiers (see itemSearch.js) - "tosses #half" or "tosses #3*brick"
+// both work. Both resolve to the entity's real name (or, for a cardinal
+// #, the same grouped "xN" list get/put use) in the broadcast text.
+//
+// Two different failure modes for two different mistakes: an unqualified
+// @/# that finds nothing falls back to "someone"/"something" - a typo in
+// otherwise-fine freeform text shouldn't nuke the whole emote. A
+// qualified # that asks for more than exists (2.pouch with only one
+// around, 3*brick with only two) fails the *entire* emote instead -
+// nothing broadcasts, the actor just gets the "there aren't N things
+// matching..." message - since that's a deliberate, specific request
+// that plainly can't be satisfied, not a vague reference to paper over.
+// @ has no qualifiers yet (see ARCHITECTURE.md) - only # does.
+//
+// This is a separate, simpler mechanism from the planned cemote parser
+// (see ARCHITECTURE.md's Combat section) - inline references anywhere in
+// free text, not a leading structured target argument plus a
+// verb/modifier keyword lexicon.
 //
 // Known wart, deliberately not fixed here: the actor's own line reuses
 // the same text as everyone else's ("You tosses..."), so third-person
@@ -24,25 +37,33 @@ import { writeToSocket } from "../utils.js";
 // per viewer, which isn't a targeting problem - it's the same "You <verb>"
 // pattern every other command in the codebase already uses, so it wants
 // its own pass across all of them, not a one-off fix just for emote.
-const TARGET_TOKEN = /^([@#])(\w+)(.*)$/;
+const TARGET_TOKEN = /^([@#])((?:\d+[.*])?\w+)(.*)$/;
 
+// Resolves one token. Returns { text } on success (including the
+// "someone"/"something" fallback) or { error } when a qualified # asked
+// for more than exists - the caller aborts the whole emote on that.
 function resolveToken(token, character, room) {
     const match = token.match(TARGET_TOKEN);
     if (!match) {
-        return token;
+        return { text: token };
     }
 
-    const [, sigil, keyword, trailing] = match;
-    const lowerKeyword = keyword.toLowerCase();
+    const [, sigil, keywordToken, trailing] = match;
 
     if (sigil === "@") {
-        const target = room.characters.find(c => c.keywords.includes(lowerKeyword));
-        return (target ? target.name : "someone") + trailing;
+        // No ordinal/cardinal for @ yet - plain keyword only.
+        const target = room.characters.find(c => c.keywords.includes(keywordToken.toLowerCase()));
+        return { text: (target ? target.name : "someone") + trailing };
     }
 
-    const item = character.inventory.find(i => i.keywords.includes(lowerKeyword)) ??
-        room.inventory.find(i => i.keywords.includes(lowerKeyword));
-    return (item ? item.name : "something") + trailing;
+    const { matches, error } = resolveItemToken(keywordToken, [character.inventory, room.inventory]);
+    if (error) {
+        return { error };
+    }
+    if (matches.length === 0) {
+        return { text: "something" + trailing };
+    }
+    return { text: formatItemList(matches.map(m => m.item)) + trailing };
 }
 
 function addTrailingPeriod(text) {
@@ -55,9 +76,16 @@ export const emote = (world, args, character) => {
     }
 
     const room = world.getRoomById(character.roomId);
-    const text = addTrailingPeriod(
-        args.map(token => resolveToken(token, character, room)).join(" ")
-    );
+    const resolvedTokens = [];
+    for (const token of args) {
+        const resolved = resolveToken(token, character, room);
+        if (resolved.error) {
+            return resolved.error;
+        }
+        resolvedTokens.push(resolved.text);
+    }
+
+    const text = addTrailingPeriod(resolvedTokens.join(" "));
 
     room.characters.forEach(char => {
         if (char !== character && char.socket) {

--- a/modules/commands/get.js
+++ b/modules/commands/get.js
@@ -1,37 +1,38 @@
 import { isContainer } from "../containers.js";
+import { resolveItemToken, formatItemList } from "../itemSearch.js";
 
 export const get = (world, args, character) => {
     const room = world.getRoomById(character.roomId);
-    const itemKeyword = args[0];
+    const itemToken = args[0];
 
-    if (!itemKeyword) {
+    if (!itemToken) {
         return "What do you want to get?";
     }
 
     const rest = args.slice(1).join(" ");
     if (!rest) {
-        return getFromRoom(room, character, itemKeyword);
+        return getFromRoom(room, character, itemToken);
     }
 
-    const containerKeyword = rest.replace(/^from /i, "");
-    return getFromContainer(room, character, itemKeyword, containerKeyword);
+    const containerToken = rest.replace(/^from /i, "");
+    return getFromContainer(room, character, itemToken, containerToken);
 };
 
-function getFromRoom(room, character, keyword) {
-    // Search the room's inventory for the item
-    const itemIndex = room.inventory.findIndex(item =>
-        item.keywords.includes(keyword)
-    );
-
-    if (itemIndex === -1) {
+function getFromRoom(room, character, itemToken) {
+    const { matches, error } = resolveItemToken(itemToken, [room.inventory]);
+    if (error) {
+        return error;
+    }
+    if (matches.length === 0) {
         return "You can't find that here.";
     }
 
-    // Move the item to the character's inventory
-    const [item] = room.inventory.splice(itemIndex, 1);
-    character.inventory.push(item);
+    for (const { item, source } of matches) {
+        source.splice(source.indexOf(item), 1);
+        character.inventory.push(item);
+    }
 
-    return `You pick up ${item.name}.`;
+    return `You pick up ${formatItemList(matches.map(m => m.item))}.`;
 }
 
 // `get <item> [from] <container>` - "from" is optional/cosmetic, stripped
@@ -39,23 +40,32 @@ function getFromRoom(room, character, keyword) {
 // keyword in the character's own inventory first, then the room floor,
 // same order look.js already searches in. Doesn't reach into a container
 // that's itself stowed inside another container; take it out first.
-function getFromContainer(room, character, itemKeyword, containerKeyword) {
-    const container = character.inventory.find(i => i.keywords.includes(containerKeyword)) ??
-        room.inventory.find(i => i.keywords.includes(containerKeyword));
-    if (!container) {
+function getFromContainer(room, character, itemToken, containerToken) {
+    const containerResult = resolveItemToken(containerToken, [character.inventory, room.inventory]);
+    if (containerResult.error) {
+        return containerResult.error;
+    }
+    if (containerResult.matches.length === 0) {
         return "You don't see that here.";
     }
+
+    const container = containerResult.matches[0].item;
     if (!isContainer(container)) {
         return `${container.name} can't hold anything.`;
     }
 
-    const itemIndex = container.inventory.findIndex(item => item.keywords.includes(itemKeyword));
-    if (itemIndex === -1) {
+    const { matches, error } = resolveItemToken(itemToken, [container.inventory]);
+    if (error) {
+        return error;
+    }
+    if (matches.length === 0) {
         return `You don't see that in ${container.name}.`;
     }
 
-    const [item] = container.inventory.splice(itemIndex, 1);
-    character.inventory.push(item);
+    for (const { item, source } of matches) {
+        source.splice(source.indexOf(item), 1);
+        character.inventory.push(item);
+    }
 
-    return `You get ${item.name} from ${container.name}.`;
+    return `You get ${formatItemList(matches.map(m => m.item))} from ${container.name}.`;
 }

--- a/modules/commands/give.js
+++ b/modules/commands/give.js
@@ -1,20 +1,20 @@
 import { writeToSocket } from "../utils.js";
+import { resolveItemToken, formatItemList } from "../itemSearch.js";
 
 export const give = (world, args, character) => {
-    const keyword = args[0];
+    const itemToken = args[0];
     const recipientName = args.slice(1).join(" ").replace(/^to /i, "");
     const room = world.getRoomById(character.roomId);
 
-    if (!keyword || !recipientName) {
+    if (!itemToken || !recipientName) {
         return "Usage: give (keyword) [to] (target)";
     }
 
-    // Find the item in the player's inventory
-    const itemIndex = character.inventory.findIndex(item =>
-        item.keywords.includes(keyword)
-    );
-
-    if (itemIndex === -1) {
+    const { matches, error } = resolveItemToken(itemToken, [character.inventory]);
+    if (error) {
+        return error;
+    }
+    if (matches.length === 0) {
         return "You can't find that.";
     }
 
@@ -27,15 +27,18 @@ export const give = (world, args, character) => {
         return "You can't find them.";
     }
 
-    // Transfer the item
-    const [item] = character.inventory.splice(itemIndex, 1);
-    recipient.inventory.push(item);
+    for (const { item, source } of matches) {
+        source.splice(source.indexOf(item), 1);
+        recipient.inventory.push(item);
+    }
+
+    const message = formatItemList(matches.map(m => m.item));
 
     // Notify the recipient
     if (recipient.socket) {
         writeToSocket(
             recipient.socket,
-            `${character.name} gives you ${item.name}.`
+            `${character.name} gives you ${message}.`
         );
     }
 
@@ -44,10 +47,10 @@ export const give = (world, args, character) => {
         if (char !== character && char !== recipient && char.socket) {
             writeToSocket(
                 char.socket,
-                `${character.name} gives ${item.name} to ${recipient.name}.`
+                `${character.name} gives ${message} to ${recipient.name}.`
             );
         }
     });
 
-    return `You give ${item.name} to ${recipient.name}.`;
+    return `You give ${message} to ${recipient.name}.`;
 };

--- a/modules/commands/items.js
+++ b/modules/commands/items.js
@@ -1,4 +1,5 @@
 import { isContainer } from "../containers.js";
+import { resolveItemToken } from "../itemSearch.js";
 
 // `items` - testing/debugging aid, not really an in-fiction verb: lists
 // every item's name *and* keywords, room floor first then the
@@ -24,17 +25,24 @@ function formatList(items) {
 
 export const items = (world, args, character) => {
     const room = world.getRoomById(character.roomId);
-    const containerKeyword = args[0];
+    const containerToken = args[0];
 
-    if (!containerKeyword) {
+    if (!containerToken) {
         return `Items in the room:\n${formatList(room.inventory)}\n\nItems in your inventory:\n${formatList(character.inventory)}`;
     }
 
-    const container = character.inventory.find(i => i.keywords.includes(containerKeyword)) ??
-        room.inventory.find(i => i.keywords.includes(containerKeyword));
-    if (!container) {
+    // Supports the same 2.pouch/3*pouch qualifiers get/put do, though a
+    // cardinal match is a moot point here - it always just peeks inside
+    // the first one.
+    const { matches, error } = resolveItemToken(containerToken, [character.inventory, room.inventory]);
+    if (error) {
+        return error;
+    }
+    if (matches.length === 0) {
         return "You don't see that here.";
     }
+
+    const container = matches[0].item;
     if (!isContainer(container)) {
         return `${container.name} can't hold anything.`;
     }

--- a/modules/commands/look.js
+++ b/modules/commands/look.js
@@ -1,5 +1,6 @@
 import { writeToSocket } from "../utils.js";
 import { isContainer } from "../containers.js";
+import { resolveItemToken } from "../itemSearch.js";
 
 // A container's contents only show up when you look at it directly, not
 // in the room/inventory listing above - keeps that listing from turning
@@ -15,10 +16,10 @@ function describeItem(item) {
 }
 
 export const look = (world, args, character) => {
-    const keyword = args[0];
+    const itemToken = args[0];
     const room = world.getRoomById(character.roomId);
 
-    if (!keyword) {
+    if (!itemToken) {
         const occupantNames = room.characters
             .filter(c => c !== character)
             .map(c => c.name);
@@ -27,25 +28,20 @@ export const look = (world, args, character) => {
         return `${room.name}\n${room.description}\nCharacters here: ${occupantNames.join(", ") || "None"}\nItems here: ${items}`;
     }
 
-    // Look for an item in the player's inventory
-    const itemInInventory = character.inventory.find(item =>
-        item.keywords.includes(keyword)
-    );
-    if (itemInInventory) {
-        return describeItem(itemInInventory);
+    // Look for an item, in the player's inventory first, then the room -
+    // supports 2.pouch/3*brick qualifiers like get/put do; a cardinal
+    // match describes each one in turn.
+    const { matches, error } = resolveItemToken(itemToken, [character.inventory, room.inventory]);
+    if (error) {
+        return error;
     }
-
-    // Look for an item in the room
-    const itemInRoom = room.inventory.find(item =>
-        item.keywords.includes(keyword)
-    );
-    if (itemInRoom) {
-        return describeItem(itemInRoom);
+    if (matches.length > 0) {
+        return matches.map(m => describeItem(m.item)).join("\n\n");
     }
 
     // Look for a character in the room
     const targetCharacter = room.characters.find(char =>
-        char.keywords.includes(keyword)
+        char.keywords.includes(itemToken)
     );
     if (targetCharacter) {
         // Notify the target character

--- a/modules/commands/put.js
+++ b/modules/commands/put.js
@@ -1,45 +1,54 @@
-import { canContain } from "../containers.js";
+import { canContainAll } from "../containers.js";
+import { resolveItemToken, formatItemList } from "../itemSearch.js";
 
-// `put <item> [in] <container>` - the one new verb containers need; drop/
-// give need no changes at all, since a container's contents move with it
-// as part of the same Item object (see ARCHITECTURE.md's Containers
-// section). "in" is optional/cosmetic, stripped the same way give.js
-// strips "to" - the container keyword is just everything after the item
-// keyword. Both the item and the container are found by keyword in the
-// character's own inventory first, then the room floor - same order
-// look.js already searches in. Doesn't reach into a container that's
-// itself stowed inside another container; take it out first.
+// `put <item> [in] <container>` - drop/give need no changes at all, since
+// a container's contents move with it as part of the same Item object
+// (see ARCHITECTURE.md's Containers section). "in" is optional/cosmetic,
+// stripped the same way give.js strips "to" - the container keyword is
+// just everything after the item keyword. Both the item and the
+// container are found by keyword in the character's own inventory first,
+// then the room floor - same order look.js already searches in. Doesn't
+// reach into a container that's itself stowed inside another container;
+// take it out first.
 export const put = (world, args, character) => {
-    const itemKeyword = args[0];
-    const containerKeyword = args.slice(1).join(" ").replace(/^in /i, "");
+    const itemToken = args[0];
+    const containerToken = args.slice(1).join(" ").replace(/^in /i, "");
 
-    if (!itemKeyword || !containerKeyword) {
+    if (!itemToken || !containerToken) {
         return "Usage: put <item> [in] <container>";
     }
 
     const room = world.getRoomById(character.roomId);
-    const findByKeyword = keyword =>
-        character.inventory.find(i => i.keywords.includes(keyword)) ??
-        room.inventory.find(i => i.keywords.includes(keyword));
+    const sources = [character.inventory, room.inventory];
 
-    const item = findByKeyword(itemKeyword);
-    if (!item) {
+    const itemResult = resolveItemToken(itemToken, sources);
+    if (itemResult.error) {
+        return itemResult.error;
+    }
+    if (itemResult.matches.length === 0) {
         return "You don't have that and don't see it here.";
     }
 
-    const container = findByKeyword(containerKeyword);
-    if (!container) {
+    const containerResult = resolveItemToken(containerToken, sources);
+    if (containerResult.error) {
+        return containerResult.error;
+    }
+    if (containerResult.matches.length === 0) {
         return "You don't see that here.";
     }
 
-    const result = canContain(container, item);
+    const container = containerResult.matches[0].item;
+    const items = itemResult.matches.map(m => m.item);
+
+    const result = canContainAll(container, items);
     if (!result.ok) {
         return result.reason;
     }
 
-    const sourceList = character.inventory.includes(item) ? character.inventory : room.inventory;
-    sourceList.splice(sourceList.indexOf(item), 1);
-    container.inventory.push(item);
+    for (const { item, source } of itemResult.matches) {
+        source.splice(source.indexOf(item), 1);
+        container.inventory.push(item);
+    }
 
-    return `You put ${item.name} in ${container.name}.`;
+    return `You put ${formatItemList(items)} in ${container.name}.`;
 };

--- a/modules/containers.js
+++ b/modules/containers.js
@@ -37,8 +37,8 @@ export function getEffectiveWeight(item) {
 }
 
 // Whether `ancestor` (transitively) already contains `item` - the cycle
-// check canContain needs, since the size/weight checks alone don't rule
-// out e.g. two same-size pouches each being put inside the other.
+// check canContainAll needs, since the size/weight checks alone don't
+// rule out e.g. two same-size pouches each being put inside the other.
 function alreadyContains(ancestor, item) {
     if (!isContainer(ancestor)) {
         return false;
@@ -54,22 +54,42 @@ function alreadyContains(ancestor, item) {
  *   player-facing message, ready to return straight from a command.
  */
 export function canContain(container, item) {
+    return canContainAll(container, [item]);
+}
+
+/**
+ * Whether `container` can accept every item in `items` *together* -
+ * checked cumulatively (a `put 3*brick in pouch` needs to weigh all
+ * three against the pouch's capacity at once, not each brick against the
+ * pouch's current, still-empty state one at a time), so a batch that
+ * individually looks fine per-item can still be rejected as a whole. All
+ * or nothing: the first item that doesn't fit rejects the entire batch,
+ * same as canContain does for one.
+ * @param {object} container
+ * @param {object[]} items
+ * @returns {{ ok: true } | { ok: false, reason: string }}
+ */
+export function canContainAll(container, items) {
     if (!isContainer(container)) {
         return { ok: false, reason: `${container.name} can't hold anything.` };
     }
-    if (container === item) {
-        return { ok: false, reason: "You can't put something inside itself." };
-    }
-    if (sizeRank(item.size) > sizeRank(container.container.maxItemSize)) {
-        return { ok: false, reason: `${item.name} is too big to fit in ${container.name}.` };
-    }
-    if (alreadyContains(item, container)) {
-        return { ok: false, reason: `${item.name} already contains ${container.name}.` };
-    }
 
-    const currentWeight = container.inventory.reduce((sum, contained) => sum + getEffectiveWeight(contained), 0);
-    if (currentWeight + getEffectiveWeight(item) > container.container.capacityWeight) {
-        return { ok: false, reason: `${container.name} doesn't have room for that much more weight.` };
+    let runningWeight = container.inventory.reduce((sum, contained) => sum + getEffectiveWeight(contained), 0);
+    for (const item of items) {
+        if (container === item) {
+            return { ok: false, reason: "You can't put something inside itself." };
+        }
+        if (sizeRank(item.size) > sizeRank(container.container.maxItemSize)) {
+            return { ok: false, reason: `${item.name} is too big to fit in ${container.name}.` };
+        }
+        if (alreadyContains(item, container)) {
+            return { ok: false, reason: `${item.name} already contains ${container.name}.` };
+        }
+
+        runningWeight += getEffectiveWeight(item);
+        if (runningWeight > container.container.capacityWeight) {
+            return { ok: false, reason: `${container.name} doesn't have room for that much more weight.` };
+        }
     }
 
     return { ok: true };

--- a/modules/itemSearch.js
+++ b/modules/itemSearch.js
@@ -1,0 +1,113 @@
+// Shared item-keyword resolution, with cardinality/ordinality (see
+// ARCHITECTURE.md). Replaces the ad-hoc `items.find(i =>
+// i.keywords.includes(keyword))` every item-handling command used to
+// duplicate, and adds two optional qualifiers on top of a plain keyword:
+//
+//   pouch      -> the first item matching "pouch" (unchanged behavior)
+//   2.pouch    -> the 2nd item matching "pouch", ordinal
+//   3*brick    -> the first 3 items matching "brick", cardinal
+//
+// Both qualifiers reduce to the same underlying question - "are there at
+// least N matches for this keyword, in this search scope?" - so
+// resolveItemToken finds every match once, then either indexes into it
+// (ordinal) or takes its front slice (cardinal). Search scope is
+// whatever ordered list of inventories the caller passes (e.g.
+// [character.inventory, room.inventory]) - the same "check inventory,
+// then the room" priority every command already used, just generalized
+// to collect N matches across it instead of stopping at the first.
+const QUALIFIED_TOKEN = /^(?:(\d+)([.*]))?(.+)$/;
+
+/**
+ * Parse a raw token into its keyword plus an optional qualifier.
+ * @param {string} rawToken
+ * @returns {{ keyword: string, ordinal: number|null, count: number|null }}
+ */
+function parseItemToken(rawToken) {
+    const [, numberStr, qualifier, keyword] = rawToken.match(QUALIFIED_TOKEN);
+    const lowerKeyword = keyword.toLowerCase();
+
+    if (!numberStr) {
+        return { keyword: lowerKeyword, ordinal: null, count: null };
+    }
+
+    const n = Number(numberStr);
+    return qualifier === "."
+        ? { keyword: lowerKeyword, ordinal: n, count: null }
+        : { keyword: lowerKeyword, ordinal: null, count: n };
+}
+
+// Every item across `sources` (searched in the given order) whose
+// keywords include `keyword`, paired with the specific array it was
+// found in - callers need that array reference back to splice the item
+// out of the right place, since a cardinal match can span sources (e.g.
+// one brick already held, two more still on the floor).
+function findAllMatches(keyword, sources) {
+    const matches = [];
+    for (const source of sources) {
+        for (const item of source) {
+            if (item.keywords.includes(keyword)) {
+                matches.push({ item, source });
+            }
+        }
+    }
+    return matches;
+}
+
+/**
+ * Resolve a raw (optionally qualified) token against an ordered list of
+ * candidate inventories.
+ * @param {string} rawToken
+ * @param {object[][]} sources - Inventories to search, in priority order.
+ * @returns {{ matches: { item: object, source: object[] }[], error: string|null }}
+ *   `matches` is empty (not an error) when a *plain* keyword finds
+ *   nothing - callers keep their own "you don't see that" wording for
+ *   that case. `error` is set only when an explicit qualifier (2.x /
+ *   N*x) asked for more matches than exist - a ready-to-return,
+ *   player-facing message, since that failure mode is the same
+ *   everywhere: fail the whole command, nothing gets moved.
+ */
+export function resolveItemToken(rawToken, sources) {
+    const { keyword, ordinal, count } = parseItemToken(rawToken);
+    const allMatches = findAllMatches(keyword, sources);
+    const requested = ordinal ?? count;
+
+    if (requested != null && allMatches.length < requested) {
+        return { matches: [], error: `There aren't ${requested} things matching "${keyword}" here.` };
+    }
+
+    if (ordinal != null) {
+        return { matches: [allMatches[ordinal - 1]], error: null };
+    }
+    if (count != null) {
+        return { matches: allMatches.slice(0, count), error: null };
+    }
+    return { matches: allMatches.length > 0 ? [allMatches[0]] : [], error: null };
+}
+
+/**
+ * Render a list of items as a natural-language list, grouping identical
+ * names with an "xN" count instead of pluralizing - item names ("a 0.5
+ * lb brick") already carry their own article, which naive pluralization
+ * ("3 a bricks") or pattern-matching ("3 bricks") can't handle generally
+ * (irregular plurals) without content having to opt in per item. Also
+ * the only option that stays correct when a cardinal match is a mix of
+ * different items, not just N of the same thing.
+ * @param {object[]} items
+ * @returns {string}
+ */
+export function formatItemList(items) {
+    const counts = new Map(); // name -> count, insertion order = first-seen order
+    for (const item of items) {
+        counts.set(item.name, (counts.get(item.name) ?? 0) + 1);
+    }
+
+    const parts = Array.from(counts, ([name, count]) => (count > 1 ? `${name} (x${count})` : name));
+
+    if (parts.length <= 1) {
+        return parts.join("");
+    }
+    if (parts.length === 2) {
+        return `${parts[0]} and ${parts[1]}`;
+    }
+    return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}

--- a/tests/containers.test.js
+++ b/tests/containers.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert/strict';
 import { Item } from '../modules/Item.js';
-import { isContainer, getEffectiveWeight, canContain } from '../modules/containers.js';
+import { isContainer, getEffectiveWeight, canContain, canContainAll } from '../modules/containers.js';
 
 function makePouch() {
     return new Item('a pouch', 'A small pouch.', ['pouch'], {
@@ -101,6 +101,50 @@ function makeItem(size, weight) {
     const backpack = makeBackpack();
     assert.equal(canContain(backpack, makeItem('small', 1)).ok, true);
     assert.equal(canContain(backpack, makePouch()).ok, true, 'a small container fits in a medium one');
+}
+
+// canContainAll: weighs the whole batch cumulatively, not each item
+// against the container's still-empty current state - three 2-weight
+// items individually fit a 5-capacity pouch, but not all three together
+{
+    const pouch = makePouch(); // capacityWeight 5
+    const items = [makeItem('small', 2), makeItem('small', 2), makeItem('small', 2)];
+
+    assert.equal(canContain(pouch, items[0]).ok, true, 'sanity check: one alone fits fine');
+    assert.equal(canContainAll(pouch, items).ok, false, 'but all three together (6) exceed capacity (5)');
+}
+
+// canContainAll: exactly at the cumulative capacity is allowed
+{
+    const pouch = makePouch(); // capacityWeight 5
+    const items = [makeItem('small', 2), makeItem('small', 3)];
+    assert.equal(canContainAll(pouch, items).ok, true);
+}
+
+// canContainAll: existing contents still count against the batch's budget
+{
+    const pouch = makePouch(); // capacityWeight 5
+    pouch.inventory.push(makeItem('small', 4));
+    assert.equal(canContainAll(pouch, [makeItem('small', 1)]).ok, true, 'fills the remaining budget exactly');
+    assert.equal(canContainAll(pouch, [makeItem('small', 0.6), makeItem('small', 0.6)]).ok, false, 'together exceed it');
+}
+
+// canContainAll: one bad item (too big) fails the whole batch, even if
+// the others in it are individually fine
+{
+    const pouch = makePouch();
+    const items = [makeItem('small', 1), makeItem('medium', 1)];
+    const result = canContainAll(pouch, items);
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /too big/);
+}
+
+// canContain is just canContainAll for a single item - same result
+// either way
+{
+    const pouch = makePouch();
+    const item = makeItem('small', 1);
+    assert.deepStrictEqual(canContain(pouch, item), canContainAll(pouch, [item]));
 }
 
 console.log('All tests passed');

--- a/tests/emote.test.js
+++ b/tests/emote.test.js
@@ -96,4 +96,48 @@ function setUpRoom() {
     assert.equal(emote(world, [], alice), 'Emote what?');
 }
 
+// #2.pouch resolves the ordinal by real name
+{
+    const { world, room, alice } = setUpRoom();
+    room.inventory.push(
+        new Item('a red pouch', 'A pouch.', ['pouch'], { size: 'small', weight: 0.5, container: { maxItemSize: 'small', capacityWeight: 5 } }),
+        new Item('a blue pouch', 'A pouch.', ['pouch'], { size: 'small', weight: 0.5, container: { maxItemSize: 'small', capacityWeight: 5 } }),
+    );
+
+    assert.equal(emote(world, ['tucks', 'a', 'hand', 'into', '#2.pouch'], alice), 'You tucks a hand into a blue pouch.');
+}
+
+// #3*brick resolves the cardinal as a grouped "xN" list, same as get/put
+{
+    const { world, room, alice } = setUpRoom();
+    room.inventory.push(
+        new Item('a 0.5 lb brick', 'A brick.', ['brick'], { size: 'small', weight: 0.5 }),
+        new Item('a 0.5 lb brick', 'A brick.', ['brick'], { size: 'small', weight: 0.5 }),
+        new Item('a 0.5 lb brick', 'A brick.', ['brick'], { size: 'small', weight: 0.5 }),
+    );
+
+    assert.equal(emote(world, ['juggles', '#3*brick'], alice), 'You juggles a 0.5 lb brick (x3)', 'ends in ")", so no period is added');
+}
+
+// A qualified # asking for more than exists fails the *whole* emote -
+// nothing broadcasts, the actor gets the "there aren't N..." message,
+// unlike the unqualified soft-fallback case above
+{
+    const { world, room, alice, baeron } = setUpRoom();
+    room.inventory.push(new Item('a pouch', 'A pouch.', ['pouch'], { size: 'small', weight: 0.5, container: { maxItemSize: 'small', capacityWeight: 5 } }));
+    const before = baeron.socket.written.length;
+
+    const result = emote(world, ['tucks', 'a', 'hand', 'into', '#2.pouch'], alice);
+
+    assert.equal(result, 'There aren\'t 2 things matching "pouch" here.');
+    assert.equal(baeron.socket.written.length, before, 'nothing should have been broadcast to the room');
+}
+
+// Same failure with zero matches at all, and with a cardinal qualifier
+{
+    const { world, alice } = setUpRoom();
+    assert.equal(emote(world, ['looks', 'for', '#2.pouch'], alice), 'There aren\'t 2 things matching "pouch" here.');
+    assert.equal(emote(world, ['gathers', '#3*brick'], alice), 'There aren\'t 3 things matching "brick" here.');
+}
+
 console.log('All tests passed');

--- a/tests/itemSearch.test.js
+++ b/tests/itemSearch.test.js
@@ -1,0 +1,103 @@
+import assert from 'assert/strict';
+import { Item } from '../modules/Item.js';
+import { resolveItemToken, formatItemList } from '../modules/itemSearch.js';
+
+function makeItem(name, keywords, weight = 1) {
+    return new Item(name, `${name}.`, keywords, { size: 'small', weight });
+}
+
+// Plain keyword (no qualifier): first match, in source-list order -
+// unchanged from the pre-qualifier behavior
+{
+    const inventory = [makeItem('a pouch', ['pouch'])];
+    const room = [makeItem('a rusty key', ['rusty', 'key'])];
+
+    const result = resolveItemToken('key', [inventory, room]);
+    assert.equal(result.error, null);
+    assert.equal(result.matches.length, 1);
+    assert.equal(result.matches[0].item.name, 'a rusty key');
+    assert.equal(result.matches[0].source, room, 'should report which array it was found in');
+}
+
+// Plain keyword, no match: empty matches, no error - callers keep their
+// own "you don't see that" wording for this case
+{
+    const result = resolveItemToken('nonexistent', [[], []]);
+    assert.deepStrictEqual(result, { matches: [], error: null });
+}
+
+// Ordinal (2.keyword): the 2nd match, across sources in priority order
+{
+    const inventory = [makeItem('a pouch (held)', ['pouch'])];
+    const room = [makeItem('a pouch (floor 1)', ['pouch']), makeItem('a pouch (floor 2)', ['pouch'])];
+
+    const result = resolveItemToken('2.pouch', [inventory, room]);
+    assert.equal(result.error, null);
+    assert.equal(result.matches.length, 1);
+    assert.equal(result.matches[0].item.name, 'a pouch (floor 1)', 'inventory match is #1, so #2 is the first floor one');
+}
+
+// Ordinal asking for more than exist: fails the whole thing, exact
+// wording the request specified
+{
+    const room = [makeItem('a pouch', ['pouch'])];
+    const result = resolveItemToken('2.pouch', [[], room]);
+    assert.deepStrictEqual(result, { matches: [], error: 'There aren\'t 2 things matching "pouch" here.' });
+}
+
+// Cardinal (N*keyword): the first N matches, across sources in order
+{
+    const inventory = [makeItem('a brick (held)', ['brick'])];
+    const room = [makeItem('a brick (floor 1)', ['brick']), makeItem('a brick (floor 2)', ['brick'])];
+
+    const result = resolveItemToken('3*brick', [inventory, room]);
+    assert.equal(result.error, null);
+    assert.deepStrictEqual(result.matches.map(m => m.item.name), ['a brick (held)', 'a brick (floor 1)', 'a brick (floor 2)']);
+    assert.equal(result.matches[0].source, inventory);
+    assert.equal(result.matches[1].source, room, 'a cardinal match can span sources');
+}
+
+// Cardinal asking for more than exist: fails the whole thing
+{
+    const room = [makeItem('a brick', ['brick'])];
+    const result = resolveItemToken('3*brick', [[], room]);
+    assert.deepStrictEqual(result, { matches: [], error: 'There aren\'t 3 things matching "brick" here.' });
+}
+
+// Keyword matching is case-insensitive, same as the pre-qualifier code
+{
+    const room = [makeItem('a rusty key', ['rusty', 'key'])];
+    assert.equal(resolveItemToken('KEY', [room]).matches.length, 1);
+    assert.equal(resolveItemToken('2.KEY', [room]).error, 'There aren\'t 2 things matching "key" here.');
+}
+
+// formatItemList: single item is just its name
+{
+    assert.equal(formatItemList([makeItem('a rusty key', ['key'])]), 'a rusty key');
+}
+
+// formatItemList: identical names group under one "xN", not pluralized
+{
+    const bricks = [makeItem('a 0.5 lb brick', ['brick']), makeItem('a 0.5 lb brick', ['brick']), makeItem('a 0.5 lb brick', ['brick'])];
+    assert.equal(formatItemList(bricks), 'a 0.5 lb brick (x3)');
+}
+
+// formatItemList: two distinct names join with "and"
+{
+    const items = [makeItem('a 0.5 lb brick', ['brick']), makeItem('a 1 lb brick', ['brick'])];
+    assert.equal(formatItemList(items), 'a 0.5 lb brick and a 1 lb brick');
+}
+
+// formatItemList: a heterogeneous cardinal match groups each distinct
+// name with its own count, in first-seen order, oxford-comma joined
+{
+    const items = [
+        makeItem('a 0.5 lb brick', ['brick']),
+        makeItem('a 0.5 lb brick', ['brick']),
+        makeItem('a 1 lb brick', ['brick']),
+        makeItem('a pouch', ['pouch']),
+    ];
+    assert.equal(formatItemList(items), 'a 0.5 lb brick (x2), a 1 lb brick, and a pouch');
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- New shared resolver, `modules/itemSearch.js`'s `resolveItemToken`, replaces the ad-hoc `items.find(i => i.keywords.includes(keyword))` that `get`/`put`/`drop`/`give`/`look`/`items`/`emote`'s `#` each used to duplicate. Adds two optional qualifiers on top of a plain keyword:
  - `pouch` → first match (unchanged)
  - `2.pouch` → ordinal: the 2nd match
  - `3*brick` → cardinal: the first 3 matches
  
  Both reduce to "are there at least N matches, in this search scope?" — the resolver finds every match once, in the same inventory-then-room priority order each command already used, then indexes or slices.
- **Fails the whole command, not a partial one.** Asking for more than exists → `There aren't N things matching "x" here.`, nothing moved. `put` extends this to batch capacity: `containers.js`'s new `canContainAll` weighs the *whole* batch cumulatively before moving anything (not each item against the container's still-empty state one at a time) — `canContain` is now just `canContainAll` for one item, so single and batch puts share one path.
- **Grouped `"xN"` phrasing**, not pluralization: `You pick up a 0.5 lb brick (x3).` — chosen because item names already carry an article, and a cardinal match isn't even guaranteed to be N of the *same* item (`3*brick` can pull a mix of weights); `formatItemList` groups by name and stays correct either way.
- Scoped to items only — `@` character targeting has no ordinal/cardinal support yet.
- `emote` has one extra wrinkle (documented in `ARCHITECTURE.md`): an *unqualified* `#`/`@` that finds nothing still soft-falls-back to `"something"`/`"someone"` (unchanged, existing behavior — a typo in freeform text shouldn't nuke the emote), but a *qualified* `#` that can't be satisfied aborts the **entire** emote, same atomic rule as everywhere else.

## Test plan
- `npm test` — 21 tests pass: new `tests/itemSearch.test.js` (plain/ordinal/cardinal resolution, cross-source matches, insufficient-match errors, case-insensitivity, `formatItemList` grouping including the heterogeneous case), extended `tests/containers.test.js` (`canContainAll` batch/cumulative capacity, `canContain` now provably equal to `canContainAll` for one item), extended `tests/emote.test.js` (ordinal/cardinal `#`, and the qualified-vs-unqualified failure-mode split).
- `npm run lint` — clean.
- Manual smoke test chaining `get`/`put`/`items`/`look`/`emote` with qualifiers against the real shipped storage-room content, plus a dedicated check that an over-capacity batch `put` leaves the container untouched:

```
== put 3*twelve 1.pouch (3 x 12lb = 36, way over pouch capacity 5) ==
a pouch doesn't have room for that much more weight.
== pouch is untouched (still empty) - verify with items ==
Items in a pouch:
  None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)