### PR TITLE
Add fuzzy (substring) keyword matching for items and characters

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -403,6 +403,37 @@ the entire emote instead - nothing broadcasts, same atomic-failure rule
 as everywhere else - because that's a specific, deliberate request that
 plainly can't be met, not a vague reference worth papering over.
 
+## Fuzzy (substring) keyword matching
+
+`modules/keywordMatch.js`'s `keywordMatches(keywords, token)` is the one
+place every item- *and* character-targeting command now checks whether
+what someone typed refers to something: a token matches if it's a
+substring of any one of the entity's keywords, not just an exact match -
+`get bri pou` finds "a brick" in "a pouch" the same way `get brick pouch`
+would. Deliberately no minimum length: even a single character matches
+(`get b p`), at the risk of also matching whatever else happens to share
+it - predictable over clever, and not a fuzziness threshold worth
+inventing before it's actually a problem in play. Composes for free with
+the `2.x`/`N*x` item qualifiers above, since those only ever wrap a
+keyword string, never caring how it gets matched (`2.bri` ordinal-selects
+across every "contains bri" match, same as `2.brick` did before).
+
+Applies everywhere a command already matched by keyword: item lookups
+(`modules/itemSearch.js`, so `get`/`put`/`drop`/`give`/`look`/`items`/
+`emote`'s `#` all get it automatically) and character lookups (`give`'s
+recipient, `whisper`, `kill`, `look`, `emote`'s `@`, and `tell` via
+`World.getOnlineCharacterByName` - which used to be an exact, global
+full-name match; it's now a fuzzy keyword search across every online
+character instead, reusing `getOnlineCharacters()`). Every one of those
+call sites used to hand-roll its own `char.keywords.includes(...)` (one
+of them, `look`'s character fallback, without even lowercasing first -
+a latent bug fixed for free by centralizing this); now there's one
+function that owns both the substring check and the lowercasing.
+
+Not extended to ordinal/cardinal - `2.bae`/`3*bae` for characters isn't
+built, a separate decision if it turns out useful, same as the item
+qualifiers' own scoping note above.
+
 ## Known gap: no input rate/size limiting
 
 `server.js`'s per-connection line buffer (`modules/utils.js`'s

--- a/modules/World.js
+++ b/modules/World.js
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto"; // For generating unique IDs
 import { Room } from "./Room.js";
+import { keywordMatches } from "./keywordMatch.js";
 
 export class World {
     constructor() {
@@ -61,19 +62,13 @@ export class World {
     }
 
     /**
-     * Find an online character by their name.
-     * @param {string} name - Character name to search for.
+     * Find an online character by keyword, across every room - fuzzy
+     * (substring) matching against their keywords, see keywordMatch.js.
+     * @param {string} name - Keyword to search for.
      * @returns {object|null} The character object if found, otherwise null.
      */
     getOnlineCharacterByName(name) {
-        const target = name.toLowerCase();
-        for (const room of this.rooms.values()) {
-            const found = room.characters.find(
-                (char) => char.name && char.name.toLowerCase() === target && char.socket
-            );
-            if (found) return found;
-        }
-        return null;
+        return this.getOnlineCharacters().find((char) => keywordMatches(char.keywords, name)) ?? null;
     }
 
     /**

--- a/modules/commands/emote.js
+++ b/modules/commands/emote.js
@@ -1,5 +1,6 @@
 import { writeToSocket } from "../utils.js";
 import { resolveItemToken, formatItemList } from "../itemSearch.js";
+import { keywordMatches } from "../keywordMatch.js";
 
 // `emote <text>` - freeform third-person action text: "Character <text>."
 // to the room, "You <text>." back to the actor. Same trailing-period rule
@@ -15,6 +16,8 @@ import { resolveItemToken, formatItemList } from "../itemSearch.js";
 // qualifiers (see itemSearch.js) - "tosses #half" or "tosses #3*brick"
 // both work. Both resolve to the entity's real name (or, for a cardinal
 // #, the same grouped "xN" list get/put use) in the broadcast text.
+// Matching is fuzzy/substring (see keywordMatch.js) - "@bae" or "#bri"
+// work the same as the full keyword would.
 //
 // Two different failure modes for two different mistakes: an unqualified
 // @/# that finds nothing falls back to "someone"/"something" - a typo in
@@ -51,8 +54,8 @@ function resolveToken(token, character, room) {
     const [, sigil, keywordToken, trailing] = match;
 
     if (sigil === "@") {
-        // No ordinal/cardinal for @ yet - plain keyword only.
-        const target = room.characters.find(c => c.keywords.includes(keywordToken.toLowerCase()));
+        // No ordinal/cardinal for @ yet - plain (fuzzy) keyword only.
+        const target = room.characters.find(c => keywordMatches(c.keywords, keywordToken));
         return { text: (target ? target.name : "someone") + trailing };
     }
 

--- a/modules/commands/give.js
+++ b/modules/commands/give.js
@@ -1,5 +1,6 @@
 import { writeToSocket } from "../utils.js";
 import { resolveItemToken, formatItemList } from "../itemSearch.js";
+import { keywordMatches } from "../keywordMatch.js";
 
 export const give = (world, args, character) => {
     const itemToken = args[0];
@@ -19,9 +20,7 @@ export const give = (world, args, character) => {
     }
 
     // Find the recipient in the current room
-    const recipient = room.characters.find(char =>
-        char.keywords.includes(recipientName.toLowerCase())
-    );
+    const recipient = room.characters.find(char => keywordMatches(char.keywords, recipientName));
 
     if (!recipient) {
         return "You can't find them.";

--- a/modules/commands/kill.js
+++ b/modules/commands/kill.js
@@ -1,15 +1,16 @@
 import { writeToSocket } from "../utils.js";
 import { engageCombat } from "../combat/session.js";
+import { keywordMatches } from "../keywordMatch.js";
 
 export const kill = (world, args, character) => {
-    const targetName = args.join(" ").toLowerCase();
+    const targetName = args.join(" ");
     if (!targetName) {
         return "Kill whom?";
     }
 
     const room = world.getRoomById(character.roomId);
     const target = room.characters.find(
-        char => char !== character && char.keywords.includes(targetName)
+        char => char !== character && keywordMatches(char.keywords, targetName)
     );
 
     if (!target) {

--- a/modules/commands/look.js
+++ b/modules/commands/look.js
@@ -1,6 +1,7 @@
 import { writeToSocket } from "../utils.js";
 import { isContainer } from "../containers.js";
 import { resolveItemToken } from "../itemSearch.js";
+import { keywordMatches } from "../keywordMatch.js";
 
 // A container's contents only show up when you look at it directly, not
 // in the room/inventory listing above - keeps that listing from turning
@@ -40,9 +41,7 @@ export const look = (world, args, character) => {
     }
 
     // Look for a character in the room
-    const targetCharacter = room.characters.find(char =>
-        char.keywords.includes(itemToken)
-    );
+    const targetCharacter = room.characters.find(char => keywordMatches(char.keywords, itemToken));
     if (targetCharacter) {
         // Notify the target character
         if (targetCharacter.socket) {

--- a/modules/commands/whisper.js
+++ b/modules/commands/whisper.js
@@ -1,4 +1,5 @@
 import { writeToSocket } from "../utils.js";
+import { keywordMatches } from "../keywordMatch.js";
 
 export const whisper = (world, args, character) => {
     const recipientName = args[0];
@@ -9,9 +10,7 @@ export const whisper = (world, args, character) => {
         return "Usage: whisper <character> <message>";
     }
 
-    const recipient = room.characters.find(char =>
-        char.keywords.includes(recipientName.toLowerCase())
-    );
+    const recipient = room.characters.find(char => keywordMatches(char.keywords, recipientName));
 
     if (!recipient) {
         return `You don't see ${recipientName} here.`;

--- a/modules/itemSearch.js
+++ b/modules/itemSearch.js
@@ -1,7 +1,9 @@
-// Shared item-keyword resolution, with cardinality/ordinality (see
-// ARCHITECTURE.md). Replaces the ad-hoc `items.find(i =>
-// i.keywords.includes(keyword))` every item-handling command used to
-// duplicate, and adds two optional qualifiers on top of a plain keyword:
+// Shared item-keyword resolution, with fuzzy matching and
+// cardinality/ordinality (see ARCHITECTURE.md). Replaces the ad-hoc
+// `items.find(i => i.keywords.includes(keyword))` every item-handling
+// command used to duplicate. Matching itself is substring-based, via
+// keywordMatch.js - "bri" finds "a brick" the same way "brick" would.
+// On top of that, two optional qualifiers:
 //
 //   pouch      -> the first item matching "pouch" (unchanged behavior)
 //   2.pouch    -> the 2nd item matching "pouch", ordinal
@@ -15,6 +17,8 @@
 // [character.inventory, room.inventory]) - the same "check inventory,
 // then the room" priority every command already used, just generalized
 // to collect N matches across it instead of stopping at the first.
+import { keywordMatches } from "./keywordMatch.js";
+
 const QUALIFIED_TOKEN = /^(?:(\d+)([.*]))?(.+)$/;
 
 /**
@@ -37,15 +41,15 @@ function parseItemToken(rawToken) {
 }
 
 // Every item across `sources` (searched in the given order) whose
-// keywords include `keyword`, paired with the specific array it was
-// found in - callers need that array reference back to splice the item
-// out of the right place, since a cardinal match can span sources (e.g.
-// one brick already held, two more still on the floor).
+// keywords match `keyword`, paired with the specific array it was found
+// in - callers need that array reference back to splice the item out of
+// the right place, since a cardinal match can span sources (e.g. one
+// brick already held, two more still on the floor).
 function findAllMatches(keyword, sources) {
     const matches = [];
     for (const source of sources) {
         for (const item of source) {
-            if (item.keywords.includes(keyword)) {
+            if (keywordMatches(item.keywords, keyword)) {
                 matches.push({ item, source });
             }
         }

--- a/modules/keywordMatch.js
+++ b/modules/keywordMatch.js
@@ -1,0 +1,21 @@
+// Shared fuzzy keyword matching (see ARCHITECTURE.md) - the one place
+// every item- and character-targeting command checks whether what
+// someone typed refers to something. A token matches if it's a
+// *substring* of any one of the entity's keywords, not just an exact
+// match - "get bri pou" finds "a brick" in "a pouch" the same way
+// "get brick pouch" would. Deliberately no minimum length: even a single
+// character matches, at the risk of also matching whatever else happens
+// to share it. Predictable over clever - lean on the existing 2.x/N*x
+// item qualifiers (modules/itemSearch.js), or just be more specific, if
+// that turns out to be a problem in practice, rather than build a
+// fuzziness threshold nobody's asked for yet.
+/**
+ * @param {string[]} keywords - Assumed already lowercase, as every
+ *   keyword in the codebase is (Character.setName, item content).
+ * @param {string} rawToken - Not assumed lowercase.
+ * @returns {boolean}
+ */
+export function keywordMatches(keywords, rawToken) {
+    const token = rawToken.toLowerCase();
+    return keywords.some(keyword => keyword.includes(token));
+}

--- a/tests/World.test.js
+++ b/tests/World.test.js
@@ -19,4 +19,17 @@ assert.deepStrictEqual(roomById, expectedRoom, 'getRoomById should return the co
 const roomByName = world.getRoomByName('Room A');
 assert.deepStrictEqual(roomByName, expectedRoom, 'getRoomByName should return the correct room');
 
+// getOnlineCharacterByName: fuzzy (substring) match, across every room,
+// only among characters with a socket
+{
+    const online = { name: 'Alice', keywords: ['alice'], socket: {} };
+    const offline = { name: 'Bob', keywords: ['bob'], socket: null };
+    world.getRoomById(id1).addCharacter(online);
+    world.getRoomById(id2).addCharacter(offline);
+
+    assert.equal(world.getOnlineCharacterByName('ali'), online, 'substring match should find the online character');
+    assert.equal(world.getOnlineCharacterByName('bob'), null, 'an offline character should not be found');
+    assert.equal(world.getOnlineCharacterByName('nobody'), null);
+}
+
 console.log('All tests passed');

--- a/tests/emote.test.js
+++ b/tests/emote.test.js
@@ -140,4 +140,14 @@ function setUpRoom() {
     assert.equal(emote(world, ['gathers', '#3*brick'], alice), 'There aren\'t 3 things matching "brick" here.');
 }
 
+// @/# matching is fuzzy (substring) - "@bae" finds Baeron, "#bri" finds
+// a brick
+{
+    const { world, room, alice } = setUpRoom();
+    room.inventory.push(new Item('a 0.5 lb brick', 'A brick.', ['brick', 'half'], { size: 'small', weight: 0.5 }));
+
+    assert.equal(emote(world, ['waves', 'at', '@bae'], alice), 'You waves at Baeron.');
+    assert.equal(emote(world, ['hefts', '#bri'], alice), 'You hefts a 0.5 lb brick.');
+}
+
 console.log('All tests passed');

--- a/tests/itemSearch.test.js
+++ b/tests/itemSearch.test.js
@@ -71,6 +71,15 @@ function makeItem(name, keywords, weight = 1) {
     assert.equal(resolveItemToken('2.KEY', [room]).error, 'There aren\'t 2 things matching "key" here.');
 }
 
+// Matching is fuzzy (substring), not exact - "bri" finds "brick", and it
+// composes with qualifiers too
+{
+    const room = [makeItem('a 0.5 lb brick', ['brick', 'half']), makeItem('a pouch', ['pouch'])];
+    assert.equal(resolveItemToken('bri', [room]).matches[0].item.name, 'a 0.5 lb brick');
+    assert.equal(resolveItemToken('pou', [room]).matches[0].item.name, 'a pouch');
+    assert.equal(resolveItemToken('2.bri', [room]).error, 'There aren\'t 2 things matching "bri" here.');
+}
+
 // formatItemList: single item is just its name
 {
     assert.equal(formatItemList([makeItem('a rusty key', ['key'])]), 'a rusty key');

--- a/tests/keywordMatch.test.js
+++ b/tests/keywordMatch.test.js
@@ -1,0 +1,41 @@
+import assert from 'assert/strict';
+import { keywordMatches } from '../modules/keywordMatch.js';
+
+// An exact match still works, same as the old .includes(keyword) check
+{
+    assert.equal(keywordMatches(['brick', 'half'], 'brick'), true);
+}
+
+// A substring anywhere in a keyword matches, not just a prefix
+{
+    assert.equal(keywordMatches(['brick'], 'bri'), true, 'prefix substring');
+    assert.equal(keywordMatches(['brick'], 'ick'), true, 'suffix substring');
+    assert.equal(keywordMatches(['brick'], 'ric'), true, 'middle substring');
+}
+
+// No minimum length - even a single character matches
+{
+    assert.equal(keywordMatches(['brick'], 'b'), true);
+    assert.equal(keywordMatches(['pouch'], 'p'), true);
+}
+
+// A keyword that doesn't contain the token at all doesn't match
+{
+    assert.equal(keywordMatches(['brick', 'half'], 'pouch'), false);
+}
+
+// Case-insensitive regardless of the token's casing (keywords are always
+// stored lowercase already)
+{
+    assert.equal(keywordMatches(['brick'], 'BRI'), true);
+    assert.equal(keywordMatches(['brick'], 'Brick'), true);
+}
+
+// Matches if *any* keyword in the list contains the token, not just the
+// first one
+{
+    assert.equal(keywordMatches(['old', 'tom'], 'tom'), true);
+    assert.equal(keywordMatches(['old', 'tom'], 'old'), true);
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- New `modules/keywordMatch.js`'s `keywordMatches(keywords, token)` — the one place every item- and character-targeting command now checks whether typed text refers to something. A token matches if it's a **substring** of any one of the entity's keywords, not just an exact match: `get bri pou` finds "a brick" in "a pouch" the same way `get brick pouch` would.
- Deliberately **no minimum length** — even a single character matches (`get b p`), at the risk of also matching whatever else happens to share it. Predictable over clever; not building a fuzziness threshold before it's actually a problem in play.
- Composes for free with the `2.x`/`N*x` item qualifiers from the last PR (`2.bri` ordinal-selects across every "contains bri" match).
- Applied everywhere a command already matched by keyword:
  - **Items**: `itemSearch.js`'s `findAllMatches` — so `get`/`put`/`drop`/`give`/`look`/`items`/`emote`'s `#` all get it automatically, no per-command changes needed beyond the one shared function.
  - **Characters**: `give`'s recipient, `whisper`, `kill`, `look`, `emote`'s `@`, and `tell` (via `World.getOnlineCharacterByName`, which used to be an exact *global full-name* match — now a fuzzy keyword search across every online character).
- Fixed a latent bug for free while centralizing this: `look`'s character-fallback search never lowercased the typed token before comparing, unlike every other character lookup in the codebase.
- Scoped like the item qualifiers before it: no ordinal/cardinal for characters yet (`2.bae`/`3*bae`) — a separate decision if it turns out useful.

## Test plan
- `npm test` — 22 tests pass: new `tests/keywordMatch.test.js` (exact match, prefix/suffix/middle substring, single-character match, case-insensitivity, multi-keyword lists), extended `tests/itemSearch.test.js` (fuzzy resolution composing with qualifiers), extended `tests/emote.test.js` (fuzzy `@`/`#`), extended `tests/World.test.js` (`getOnlineCharacterByName`'s new fuzzy/online-only behavior).
- `npm run lint` — clean.
- Manual smoke test reproducing the exact request, against real shipped content:

```
== get pou (grab a pouch, fuzzy) ==
You pick up a pouch.
== put bri pou (fuzzy put a brick in the held pouch) ==
You put a 0.5 lb brick in a pouch.
== get bri pou (fuzzy: get the brick back out of the pouch) ==
You get a 0.5 lb brick from a pouch.
```

Also verified `whisper`/`tell`/`look` all resolve a character via a short fuzzy fragment (`bae` → Baeron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)